### PR TITLE
Feature/filters mobile view and ViewportService

### DIFF
--- a/public/i18n/ar.json
+++ b/public/i18n/ar.json
@@ -153,6 +153,7 @@
     "DETAILS_DESC": "نص مؤقت لتفاصيل الأصل."
   },
   "UI": {
+    "FILTERS": "تصفية",
     "SEARCH_IN_RESOURCES": "البحث في الموارد",
     "CATEGORY_FILTERS": "الفئات",
     "LICENSE_FILTERS": "التراخيص (CreativeCommons)",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -153,6 +153,7 @@
     "DETAILS_DESC": "This is a placeholder for asset details."
   },
   "UI": {
+    "FILTERS": "Filters",
     "SEARCH_IN_RESOURCES": "Search in resources",
     "CATEGORY_FILTERS": "Categories",
     "LICENSE_FILTERS": "Licenses (CreativeCommons)",

--- a/src/app/core/constants/breakpoints.ts
+++ b/src/app/core/constants/breakpoints.ts
@@ -1,0 +1,8 @@
+export const BREAKPOINTS = {
+  xs: 480,
+  sm: 576,
+  md: 768,
+  lg: 992,
+  xl: 1200,
+  xxl: 1600,
+} as const;

--- a/src/app/core/services/viewport.service.ts
+++ b/src/app/core/services/viewport.service.ts
@@ -1,0 +1,46 @@
+import { computed, Injectable, OnDestroy, signal } from '@angular/core';
+import { fromEvent, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged, map, startWith } from 'rxjs/operators';
+import { BREAKPOINTS } from '../constants/breakpoints';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ViewportService implements OnDestroy {
+  private subscription: Subscription = new Subscription();
+
+  // Signal for raw window width
+  readonly width = signal<number>(typeof window !== 'undefined' ? window.innerWidth : 0);
+
+  // Computed signals for specific breakpoints
+  readonly isMobile = computed(() => this.width() <= BREAKPOINTS.md);
+  readonly isTablet = computed(
+    () => this.width() > BREAKPOINTS.md && this.width() <= BREAKPOINTS.lg
+  );
+  readonly isDesktop = computed(() => this.width() > BREAKPOINTS.lg);
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      this.initResizeListener();
+    }
+  }
+
+  private initResizeListener() {
+    const resize$ = fromEvent(window, 'resize').pipe(
+      debounceTime(200),
+      map(() => window.innerWidth),
+      distinctUntilChanged(),
+      startWith(window.innerWidth)
+    );
+
+    this.subscription.add(
+      resize$.subscribe((w) => {
+        this.width.set(w);
+      })
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+}

--- a/src/app/features/gallery/components/assets-listing/assets-listing.component.ts
+++ b/src/app/features/gallery/components/assets-listing/assets-listing.component.ts
@@ -1,5 +1,6 @@
 import { isPlatformServer } from '@angular/common';
 import { Component, inject, PLATFORM_ID, signal } from '@angular/core';
+import { ViewportService } from '../../../../core/services/viewport.service';
 import { AssetCardSkeletonComponent } from '../../../../shared/components/asset-card-skeleton/asset-card-skeleton.component';
 import { FiltersComponent } from '../../../../shared/components/filters/filters.component';
 import { Asset } from '../../models/assets.model';
@@ -15,6 +16,7 @@ import { AssetCardComponent } from '../asset-card/asset-card.component';
 export class AssetsListingComponent {
   private readonly assetsService = inject(AssetsService);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly viewportService = inject(ViewportService);
 
   isServer = isPlatformServer(this.platformId);
 
@@ -32,7 +34,7 @@ export class AssetsListingComponent {
     if (this.isServer) {
       return [];
     }
-    const count = window.innerWidth < 768 ? 4 : 8;
+    const count = this.viewportService.isMobile() ? 4 : 8;
     return Array.from({ length: count });
   }
 

--- a/src/app/features/publishers/pages/publisher-details/publisher-details.page.ts
+++ b/src/app/features/publishers/pages/publisher-details/publisher-details.page.ts
@@ -2,6 +2,7 @@ import { isPlatformServer } from '@angular/common';
 import { Component, inject, OnInit, PLATFORM_ID, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
+import { ViewportService } from '../../../../core/services/viewport.service';
 import { AssetCardComponent } from '../../../../features/gallery/components/asset-card/asset-card.component';
 import { AssetCardSkeletonComponent } from '../../../../shared/components/asset-card-skeleton/asset-card-skeleton.component';
 import { BreadcrumbComponent } from '../../../../shared/components/breadcrumb/breadcrumb.component';
@@ -27,6 +28,7 @@ export class PublisherDetailsPage implements OnInit {
   private readonly route = inject(ActivatedRoute);
 
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly viewportService = inject(ViewportService);
 
   isServer = isPlatformServer(this.platformId);
 
@@ -49,7 +51,7 @@ export class PublisherDetailsPage implements OnInit {
     if (this.isServer) {
       return [];
     }
-    const count = window.innerWidth < 768 ? 4 : 8;
+    const count = this.viewportService.isMobile() ? 4 : 8;
     return Array.from({ length: count });
   }
 

--- a/src/app/shared/components/filters/filters.component.html
+++ b/src/app/shared/components/filters/filters.component.html
@@ -1,7 +1,13 @@
 @if (isMobileView()) {
   <ng-container *ngTemplateOutlet="searchFilter"></ng-container>
 
-  <button nz-button nzType="text" class="filters__toggle-btn" (click)="toggleFiltersDrawer()">
+  <button
+    nz-button
+    nzType="text"
+    class="filters__toggle-btn"
+    (click)="toggleFiltersDrawer()"
+    [attr.aria-label]="'UI.FILTERS' | translate"
+  >
     <i class="bx bx-filter"></i>
     {{ 'UI.FILTERS' | translate }}
   </button>

--- a/src/app/shared/components/filters/filters.component.html
+++ b/src/app/shared/components/filters/filters.component.html
@@ -1,4 +1,30 @@
-<div class="filters__container">
+@if (isMobileView()) {
+  <ng-container *ngTemplateOutlet="searchFilter"></ng-container>
+
+  <button nz-button nzType="text" class="filters__toggle-btn" (click)="toggleFiltersDrawer()">
+    <i class="bx bx-filter"></i>
+    {{ 'UI.FILTERS' | translate }}
+  </button>
+
+  <nz-drawer
+    [nzVisible]="showFiltersDrawer()"
+    [nzTitle]="'UI.FILTERS' | translate"
+    nzPlacement="bottom"
+    nzHeight="80vh"
+    (nzOnClose)="showFiltersDrawer.set(false)"
+  >
+    <ng-container *nzDrawerContent>
+      <ng-container *ngTemplateOutlet="otherFilters"></ng-container>
+    </ng-container>
+  </nz-drawer>
+} @else {
+  <div class="filters__container">
+    <ng-container *ngTemplateOutlet="searchFilter"></ng-container>
+    <ng-container *ngTemplateOutlet="otherFilters"></ng-container>
+  </div>
+}
+
+<ng-template #searchFilter>
   <!-- Search Filter -->
   <div class="card filters__card">
     <div class="filters__card-header">
@@ -16,44 +42,48 @@
       />
     </div>
   </div>
+</ng-template>
 
-  <!-- Category Filter -->
-  <div class="card filters__card">
-    <div class="filters__card-header">
-      <i class="bx bx-categories"></i>
-      <h3 class="filters__card-title">{{ 'UI.CATEGORY_FILTERS' | translate }}</h3>
+<ng-template #otherFilters>
+  <div class="filters__others">
+    <!-- Category Filter -->
+    <div class="card filters__card">
+      <div class="filters__card-header">
+        <i class="bx bx-categories"></i>
+        <h3 class="filters__card-title">{{ 'UI.CATEGORY_FILTERS' | translate }}</h3>
+      </div>
+
+      <div class="filters__card-content">
+        <nz-checkbox-group
+          [nzOptions]="categoriesOptions"
+          [(ngModel)]="categoriesSelection"
+          (ngModelChange)="onCategoriesSelectionChange($event)"
+        />
+      </div>
     </div>
 
-    <div class="filters__card-content">
-      <nz-checkbox-group
-        [nzOptions]="categoriesOptions"
-        [(ngModel)]="categoriesSelection"
-        (ngModelChange)="onCategoriesSelectionChange($event)"
-      />
+    <!-- License Filter -->
+    <div class="card filters__card">
+      <div class="filters__card-header">
+        <i class="bx bx-receipt"></i>
+        <h3 class="filters__card-title">{{ 'UI.LICENSE_FILTERS' | translate }}</h3>
+      </div>
+
+      <div class="filters__card-content">
+        <nz-checkbox-group
+          [(ngModel)]="licensesSelection"
+          (ngModelChange)="onLicensesSelectionChange($event)"
+        >
+          @for (license of licensesOptions; track license.value) {
+            <div class="filters__card-content-license">
+              <label nz-checkbox [nzValue]="license.value" [htmlFor]="license.value">{{
+                license.label | translate
+              }}</label>
+              <app-license-tag [license]="license.value" [id]="license.value" />
+            </div>
+          }
+        </nz-checkbox-group>
+      </div>
     </div>
   </div>
-
-  <!-- License Filter -->
-  <div class="card filters__card">
-    <div class="filters__card-header">
-      <i class="bx bx-receipt"></i>
-      <h3 class="filters__card-title">{{ 'UI.LICENSE_FILTERS' | translate }}</h3>
-    </div>
-
-    <div class="filters__card-content">
-      <nz-checkbox-group
-        [(ngModel)]="licensesSelection"
-        (ngModelChange)="onLicensesSelectionChange($event)"
-      >
-        @for (license of licensesOptions; track license.value) {
-          <div class="filters__card-content-license">
-            <label nz-checkbox [nzValue]="license.value" [htmlFor]="license.value">{{
-              license.label | translate
-            }}</label>
-            <app-license-tag [license]="license.value" [id]="license.value" />
-          </div>
-        }
-      </nz-checkbox-group>
-    </div>
-  </div>
-</div>
+</ng-template>

--- a/src/app/shared/components/filters/filters.component.less
+++ b/src/app/shared/components/filters/filters.component.less
@@ -5,6 +5,36 @@
     gap: 16px;
   }
 
+  &__others {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  &__toggle-btn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 16px;
+    padding: 12px;
+    margin-top: 12px;
+    height: auto;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    background-color: #fff;
+
+    i {
+      font-size: 20px;
+    }
+
+    &:hover {
+      background-color: #f9fafb;
+      border-color: #d1d5db;
+    }
+  }
+
   &__card {
     display: flex;
     flex-direction: column;

--- a/src/app/shared/components/filters/filters.component.ts
+++ b/src/app/shared/components/filters/filters.component.ts
@@ -1,18 +1,28 @@
-import { Component, inject, output, signal, OnDestroy } from '@angular/core';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { NzCheckboxComponent, NzCheckboxGroupComponent } from 'ng-zorro-antd/checkbox';
-import { NzInputModule } from 'ng-zorro-antd/input';
-import { Categories } from '../../../core/enums/categories.enum';
+import { NgTemplateOutlet } from '@angular/common';
+import { Component, OnDestroy, inject, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzCheckboxComponent, NzCheckboxGroupComponent } from 'ng-zorro-antd/checkbox';
+import { NzDrawerModule } from 'ng-zorro-antd/drawer';
+import { NzIconModule } from 'ng-zorro-antd/icon';
+import { NzInputModule } from 'ng-zorro-antd/input';
+import { Subject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs';
+import { Categories } from '../../../core/enums/categories.enum';
 import { Licenses } from '../../../core/enums/licenses.enum';
 import { LicenseTagComponent } from '../license-tag/license-tag.component';
-import { Subject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs';
+
+import { ViewportService } from '../../../core/services/viewport.service';
 
 @Component({
   selector: 'app-filters',
   imports: [
     NzInputModule,
+    NzButtonModule,
+    NzIconModule,
+    NzDrawerModule,
     TranslatePipe,
+    NgTemplateOutlet,
     NzCheckboxGroupComponent,
     NzCheckboxComponent,
     FormsModule,
@@ -23,6 +33,7 @@ import { Subject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs';
 })
 export class FiltersComponent implements OnDestroy {
   private readonly translate = inject(TranslateService);
+  private readonly viewportService = inject(ViewportService);
   private readonly destroy$ = new Subject<void>();
   private readonly searchSubject$ = new Subject<string>();
 
@@ -68,6 +79,9 @@ export class FiltersComponent implements OnDestroy {
   licensesSelection = signal<string[]>([]);
   licensesSelectionChange = output<string[]>();
 
+  readonly isMobileView = this.viewportService.isMobile;
+  showFiltersDrawer = signal(false);
+
   constructor() {
     // Set up debounced search with 300ms delay
     this.searchSubject$
@@ -75,6 +89,12 @@ export class FiltersComponent implements OnDestroy {
       .subscribe((query) => {
         this.searchQueryChange.emit(query);
       });
+  }
+
+  // ngOnInit removed as it was empty
+
+  toggleFiltersDrawer() {
+    this.showFiltersDrawer.update((v) => !v);
   }
 
   onSearchQueryChange(event: string) {

--- a/src/app/shared/components/license-tag/license-tag.component.ts
+++ b/src/app/shared/components/license-tag/license-tag.component.ts
@@ -11,15 +11,7 @@ import { ViewportService } from '../../../core/services/viewport.service';
 @Component({
   selector: 'app-license-tag',
   standalone: true,
-  imports: [
-    NgClass,
-    NgTemplateOutlet,
-    NzTagModule,
-    NzIconModule,
-    NzPopoverModule,
-    NzDrawerModule,
-    NgTemplateOutlet,
-  ],
+  imports: [NgClass, NgTemplateOutlet, NzTagModule, NzIconModule, NzPopoverModule, NzDrawerModule],
   templateUrl: './license-tag.component.html',
   styleUrls: ['./license-tag.component.less'],
 })

--- a/src/app/shared/components/license-tag/license-tag.component.ts
+++ b/src/app/shared/components/license-tag/license-tag.component.ts
@@ -1,40 +1,38 @@
 import { NgClass, NgTemplateOutlet } from '@angular/common';
-import { Component, HostListener, OnInit, inject, input, signal } from '@angular/core';
+import { Component, inject, input, signal } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { NzDrawerModule } from 'ng-zorro-antd/drawer';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzPopoverModule } from 'ng-zorro-antd/popover';
 import { NzTagModule } from 'ng-zorro-antd/tag';
 import { Licenses, LicensesColors } from '../../../core/enums/licenses.enum';
+import { ViewportService } from '../../../core/services/viewport.service';
 
 @Component({
   selector: 'app-license-tag',
   standalone: true,
-  imports: [NgClass, NgTemplateOutlet, NzTagModule, NzIconModule, NzPopoverModule, NzDrawerModule],
+  imports: [
+    NgClass,
+    NgTemplateOutlet,
+    NzTagModule,
+    NzIconModule,
+    NzPopoverModule,
+    NzDrawerModule,
+    NgTemplateOutlet,
+  ],
   templateUrl: './license-tag.component.html',
   styleUrls: ['./license-tag.component.less'],
 })
-export class LicenseTagComponent implements OnInit {
+export class LicenseTagComponent {
   license = input.required<Licenses>();
   muted = input<boolean>(false);
 
   showPopover = signal(false);
-  isMobileView = signal(false);
+
+  private viewportService = inject(ViewportService);
+  isMobileView = this.viewportService.isMobile;
 
   private translate = inject(TranslateService);
-
-  ngOnInit() {
-    if (typeof window !== 'undefined') {
-      this.isMobileView.set(window.innerWidth <= 768);
-    }
-  }
-
-  @HostListener('window:resize')
-  onResize() {
-    if (typeof window !== 'undefined') {
-      this.isMobileView.set(window.innerWidth <= 768);
-    }
-  }
 
   togglePopover() {
     this.showPopover.update((v) => !v);


### PR DESCRIPTION
# Pull Request

## Description

This PR refactors the mobile view detection logic to eliminate redundancy and "magic numbers" across the codebase. It introduces a centralized, reactive ViewportService and a standard set of breakpoint constants aligned with Ng-Zorro Ant Design.

It also introduces a new mobile UI/UX for the Filters selector, providing a fully redesigned filter drawer optimized for small screens, improved spacing, revised grouping, better touch ergonomics, and a clean bottom-sheet interaction model.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Related Issue

Closes #22 

## Changes Made

- New Service: Created `src/app/core/services/viewport.service.ts` to centrally manage window resize events using RxJS and expose Signals (isMobile, isTablet, width) for components.
- New Constants: Added `src/app/core/constants/breakpoints.ts` defining standard breakpoints (e.g., md: 768, lg: 992) to match Ant Design.
- Refactoring:
  - FiltersComponent: Removed manual HostListener('window:resize') and replaced with ViewportService.isMobile.
  - LicenseTagComponent: Replaced local resizing logic with ViewportService.
  - PublisherDetailsPage: Replaced hardcoded window.innerWidth < 768 with ViewportService.isMobile() for skeleton count.
  - AssetsListingComponent: Replaced hardcoded window.innerWidth < 768 with ViewportService.isMobile() for skeleton count.
- New Feature – Mobile Filters UI/UX:
  - Implemented redesigned filter drawer for mobile, including: Sticky header with close action, Full-height sheet with improved scrolling, and keeing the search input for better UX

## Screenshots


<img width="1768" height="3244" alt="Screen Shot 2025-12-06 at 20 26 09" src="https://github.com/user-attachments/assets/80ecd4cb-7929-4f8f-9ee6-c71f30c58c87" />


<img width="1768" height="3244" alt="Screen Shot 2025-12-06 at 20 26 14" src="https://github.com/user-attachments/assets/36c6ea94-6a88-45c1-99ae-66fb3cffa49d" />

<img width="460" height="917" alt="Screenshot 2025-12-07 at 08-43-04 إتقان نظام إدارة المحتوى" src="https://github.com/user-attachments/assets/135d6f0b-fcc9-4859-87b7-711624d96cd9" />

## Testing
- [ ] Unit tests pass locally
- [ ] Build succeeds without errors
- [ ] Tested on Chrome
- [x] Tested on Firefox
- [ ] Tested on Safari
- [x] Tested on mobile browsers
- [x] Tested in development environment
- [ ] Tested in staging environment (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the README.md (if needed)
- [ ] I have updated the CHANGELOG.md (if needed)

## Additional Context

This refactoring sets the foundation for a more responsive and maintainable codebase.

The new mobile filter UI/UX delivers a cleaner, touch-optimized flow while fully respecting the license tag drawer, allowing it to open and close above the filter layer without any interference.

## Dependencies


## Breaking Changes

## Reviewer Notes
