### PR TITLE
fix(license-tag): add inline mode for mobile and stop duplicate overlay

### DIFF
--- a/src/app/shared/components/filters/filters.component.html
+++ b/src/app/shared/components/filters/filters.component.html
@@ -85,7 +85,11 @@
               <label nz-checkbox [nzValue]="license.value" [htmlFor]="license.value">{{
                 license.label | translate
               }}</label>
-              <app-license-tag [license]="license.value" [id]="license.value" />
+              <app-license-tag
+                [license]="license.value"
+                [id]="license.value"
+                [mode]="isMobileView() ? 'inline' : 'default'"
+              />
             </div>
           }
         </nz-checkbox-group>

--- a/src/app/shared/components/license-tag/license-tag.component.html
+++ b/src/app/shared/components/license-tag/license-tag.component.html
@@ -1,22 +1,42 @@
 <nz-tag
   [nzColor]="nzColor"
   [ngClass]="{ muted: muted() }"
-  [nz-popover]="!isMobileView() ? licenseContent : undefined"
-  [nzPopoverTitle]="!isMobileView() ? licenseFullTitle : undefined"
-  [nzPopoverContent]="!isMobileView() ? licenseContent : undefined"
+  [nz-popover]="!isMobileView() && mode() !== 'inline' ? licenseContent : undefined"
+  [nzPopoverTitle]="!isMobileView() && mode() !== 'inline' ? licenseFullTitle : undefined"
+  [nzPopoverContent]="!isMobileView() && mode() !== 'inline' ? licenseContent : undefined"
   nzPopoverTrigger="hover"
-  (click)="isMobileView() ? togglePopover() : null"
+  role="button"
+  aria-expanded="{{ expanded() }}"
+  aria-label="License info"
+  (click)="handleTagClick()"
 >
-  <nz-icon nzType="info-circle" nzTheme="outline" class="tag-icon"></nz-icon>
-  {{ licenseTitle }}
+  <span class="tag-label">
+    <i class="bx bx-info-circle tag-icon" aria-hidden="true"></i>
+    <span>{{ licenseTitle }}</span>
+    @if (mode() === 'inline') {
+      <i
+        class="bx toggle-icon"
+        [ngClass]="expanded() ? 'bx-chevron-up' : 'bx-chevron-down'"
+        aria-hidden="true"
+      ></i>
+    }
+  </span>
 </nz-tag>
 
-@if (isMobileView()) {
+@if (mode() === 'inline' && expanded()) {
+  <div class="inline-details" role="region" aria-label="License details">
+    <ng-container *ngTemplateOutlet="licenseContent"></ng-container>
+  </div>
+}
+
+@if (isMobileView() && mode() !== 'inline') {
   <nz-drawer
     [nzVisible]="showPopover()"
     [nzTitle]="licenseFullTitle"
     nzPlacement="bottom"
     nzHeight="auto"
+    role="dialog"
+    aria-modal="true"
     (nzOnClose)="showPopover.set(false)"
   >
     <ng-container *nzDrawerContent>
@@ -33,8 +53,10 @@
       target="_blank"
       rel="noopener noreferrer"
       class="license-link"
+      role="link"
+      aria-label="Learn more about {{ licenseTitle }}"
     >
-      <i class="bx bx-arrow-out-up-left-stroke-square"></i>
+      <i class="bx bx-arrow-out-up-left-stroke-square" aria-hidden="true"></i>
       <span>{{ LearnMoreText }}</span>
     </a>
   </div>

--- a/src/app/shared/components/license-tag/license-tag.component.less
+++ b/src/app/shared/components/license-tag/license-tag.component.less
@@ -1,4 +1,27 @@
-// Unified content styling for both popover and drawer
+:host {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.tag-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tag-icon,
+.toggle-icon {
+  font-size: 16px;
+  line-height: 0;
+}
+
+.toggle-icon {
+  font-size: 1.2em;
+}
+
+/* Unified content styling for popover and drawer */
 .license-content {
   max-width: 320px;
   display: flex;
@@ -17,20 +40,63 @@
   display: inline-flex;
   gap: 4px;
   align-items: center;
-  padding: 8px 0px;
+  padding: 8px 0;
   font-size: 14px;
   transition: opacity 0.2s ease;
   align-self: flex-start;
   justify-content: center;
+}
 
-  &:hover {
-    opacity: 0.7;
+.license-link:hover {
+  opacity: 0.7;
+}
+
+.license-link span {
+  text-decoration: underline;
+}
+
+.license-link i {
+  font-size: 16px;
+  margin-inline-end: 2px;
+}
+
+/* Inline details styling */
+.inline-details {
+  margin-top: 8px;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.02);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 8px;
+  animation: slideDown 0.2s ease-out;
+  width: 100%;
+}
+
+.inline-details .license-content {
+  max-width: 100%;
+  padding: 0;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
   }
-  span {
-    text-decoration: underline;
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
-  i {
-    font-size: 16px;
-    margin-inline-end: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inline-details {
+    animation: none;
+  }
+
+  .license-link,
+  .tag-label,
+  .toggle-icon,
+  .tag-icon {
+    transition: none;
+    animation: none;
   }
 }

--- a/src/app/shared/components/license-tag/license-tag.component.ts
+++ b/src/app/shared/components/license-tag/license-tag.component.ts
@@ -18,16 +18,24 @@ import { ViewportService } from '../../../core/services/viewport.service';
 export class LicenseTagComponent {
   license = input.required<Licenses>();
   muted = input<boolean>(false);
+  mode = input<'default' | 'inline'>('default');
 
   showPopover = signal(false);
+  expanded = signal(false);
 
   private viewportService = inject(ViewportService);
   isMobileView = this.viewportService.isMobile;
 
   private translate = inject(TranslateService);
 
-  togglePopover() {
-    this.showPopover.update((v) => !v);
+  handleTagClick() {
+    if (this.isMobileView() || this.mode() === 'inline') {
+      if (this.mode() === 'inline') {
+        this.expanded.update((v) => !v);
+      } else {
+        this.showPopover.update((v) => !v);
+      }
+    }
   }
 
   get nzColor() {


### PR DESCRIPTION
# Pull Request

## Description
Fixes the issue where two bottom sheets opened at the same time when tapping a license tag on mobile. Introduces an inline mode for mobile use inside filters and adds proper accessibility.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Changes Made
- Added [mode]="isMobileView() ? 'inline' : 'default'" in filters.component.html to force inline behavior inside mobile filters.
- Only one layer opens at a time, No more double overlay when clicking license inside filters.
- Kept the decktop popup behavior unchanged.
- Cleaner UX on mobile and consistent behavior on desktop.
- Added ARIA attributes and semantic roles.

## Screenshots
<img width="429" height="917" alt="Screenshot 2025-12-11 at 09-24-04 إتقان نظام إدارة المحتوى" src="https://github.com/user-attachments/assets/c80c0868-d7a2-495f-b585-d7907f39fb36" />
<img width="429" height="917" alt="Screenshot 2025-12-11 at 09-23-54 إتقان نظام إدارة المحتوى" src="https://github.com/user-attachments/assets/de882c9d-bdd6-4a2a-bb03-4266ddd7c51c" />
<img width="429" height="917" alt="Screenshot 2025-12-11 at 09-23-44 إتقان نظام إدارة المحتوى" src="https://github.com/user-attachments/assets/d99bc262-6929-43b1-a78b-03853fd16ea5" />


## Testing
- [x] Unit tests pass locally
- [x] Build succeeds without errors
- [x] Tested on Chrome
- [x] Tested on Firefox
- [ ] Tested on Safari
- [x] Tested on mobile browsers
- [x] Tested in development environment
- [ ] Tested in staging environment (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the README.md (if needed)
- [ ] I have updated the CHANGELOG.md (if needed)