### PR TITLE
fix: add unique key to skeleton array generation to fix the error NG0955

### DIFF
--- a/src/app/features/gallery/components/assets-listing/assets-listing.component.html
+++ b/src/app/features/gallery/components/assets-listing/assets-listing.component.html
@@ -7,7 +7,7 @@
   />
   <div class="assets-listing__grid" [attr.aria-busy]="loading()">
     @if (!isServer && loading()) {
-      @for (item of getSkeletonArray(); track item) {
+      @for (item of getSkeletonArray(); track $index) {
         <app-asset-card-skeleton />
       }
     } @else {


### PR DESCRIPTION
# Pull Request

## Description
This update resolves a runtime error (NG0955) in the 
AssetsListingComponent
 where the skeleton loader caused a "duplicate keys" exception. The issue arose because the skeleton array consists of identical undefined values, and tracking by item resulted in non-unique keys for the collection.
 
 ~~~
 NG0955: The provided track expression resulted in duplicated keys for a given collection. Adjust the tracking expression such that it uniquely identifies all the items in the collection. Duplicated keys were: 
key "" at index "0" and "1", 
key "" at index "1" and "2", 
key "" at index "2" and "3". Find more at https://v20.angular.dev/errors/NG0955
 ~~~

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Changes Made

Fix Template Tracking: Updated the @for loop in 'assets-listing.component.html'  to use track $index instead of track item. This ensures each skeleton card has a unique identifier during rendering, preventing the Angular change detection error.

## Testing

- [ ] Unit tests pass locally
- [x] Build succeeds without errors
- [x] Tested on Chrome
- [x] Tested on Firefox
- [ ] Tested on Safari
- [ ] Tested on mobile browsers
- [x] Tested in development environment
- [ ] Tested in staging environment (if applicable)