### PR TITLE
fix: add error and loading states to asset details page

### DIFF
--- a/public/i18n/ar.json
+++ b/public/i18n/ar.json
@@ -180,6 +180,8 @@
     "RESOURCE_ACTIONS": "إجراءات المورد",
     "USAGE_STANDARDS": "معايير الاستخدام",
     "DOWNLOAD_ORIGINAL_RESOURCE": "تحميل المورد الأصلي",
+    "BACK_TO_GALLERY": "العودة إلى المعرض",
+    "SOMETHING_WENT_WRONG": "حدث خطأ ما",
     "DOWNLOAD_RESOURCE": "تحميل المورد",
     "DOWNLOADING": "جاري التحميل...",
     "LICENSE_INFO": "معلومات الترخيص",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -180,6 +180,8 @@
     "RESOURCE_ACTIONS": "Resource Actions",
     "USAGE_STANDARDS": "Usage Standards",
     "DOWNLOAD_ORIGINAL_RESOURCE": "Download Original Resource",
+    "BACK_TO_GALLERY": "Back to Gallery",
+    "SOMETHING_WENT_WRONG": "Something went wrong",
     "DOWNLOAD_RESOURCE": "Download Resource",
     "DOWNLOADING": "Downloading...",
     "LICENSE_INFO": "License Information",

--- a/src/app/features/gallery/pages/asset-details/asset-details.page.html
+++ b/src/app/features/gallery/pages/asset-details/asset-details.page.html
@@ -1,8 +1,33 @@
 <div class="asset-details-container">
   <app-breadcrumb />
 
-  <!-- <nz-spin [nzSpinning]="loading()" nzSize="large"> -->
-  @if (asset()) {
+  <!-- Loading / Error / Content states (mutually exclusive) -->
+  @if (loading()) {
+    <div class="state-container" role="status" aria-live="polite">
+      <nz-spin nzSize="large"></nz-spin>
+      <p class="state-message">{{ 'UI.LOADING_ASSET_DETAILS' | translate }}</p>
+    </div>
+  } @else if (errorState() === 'not-found') {
+    <div class="state-container" role="alert">
+      <i class="bx bx-search-alt state-icon not-found-icon"></i>
+      <h2 class="state-title">{{ 'UI.ASSET_NOT_FOUND' | translate }}</h2>
+      <p class="state-message">{{ 'ERRORS.NOT_FOUND' | translate }}</p>
+      <a routerLink="/gallery" nz-button nzType="primary" class="state-action-button">
+        <i class="bx bx-arrow-back"></i>
+        {{ 'UI.BACK_TO_GALLERY' | translate }}
+      </a>
+    </div>
+  } @else if (errorState() === 'server-error') {
+    <div class="state-container" role="alert">
+      <i class="bx bx-error-circle state-icon error-icon"></i>
+      <h2 class="state-title">{{ 'UI.SOMETHING_WENT_WRONG' | translate }}</h2>
+      <p class="state-message">{{ 'ERRORS.SERVER_ERROR' | translate }}</p>
+      <button nz-button nzType="primary" class="state-action-button" (click)="retryLoad()">
+        <i class="bx bx-refresh"></i>
+        {{ 'UI.TRY_AGAIN' | translate }}
+      </button>
+    </div>
+  } @else if (asset()) {
     <div class="asset-details-content">
       <!-- Main Content -->
       <div class="main-content">
@@ -105,8 +130,12 @@
         </div>
       </div>
     </div>
+  } @else {
+    <div class="state-container" role="status" aria-live="polite">
+      <nz-spin nzSize="large"></nz-spin>
+      <p class="state-message">{{ 'UI.LOADING_ASSET_DETAILS' | translate }}</p>
+    </div>
   }
-  <!-- </nz-spin> -->
 
   <!-- Access Request Modal -->
   <nz-modal

--- a/src/app/features/gallery/pages/asset-details/asset-details.page.less
+++ b/src/app/features/gallery/pages/asset-details/asset-details.page.less
@@ -234,9 +234,57 @@
   color: var(--color-neutral-600);
 }
 
-// Loading state
-nz-spin {
+// Loading & Error states
+.state-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   min-height: 400px;
+  text-align: center;
+  padding: 2rem;
+}
+
+.state-icon {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+}
+
+.not-found-icon {
+  color: var(--color-neutral-400);
+}
+
+.error-icon {
+  color: var(--color-danger-500, #d73a4a);
+}
+
+.state-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-neutral-600);
+  margin: 0 0 0.5rem 0;
+}
+
+.state-message {
+  font-size: 1rem;
+  color: var(--color-neutral-400);
+  margin: 0.5rem 0 1.5rem 0;
+  max-width: 400px;
+}
+
+.state-action-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+// Flip back-arrow icon in RTL so it points right (semantically "back")
+:host-context([dir="rtl"]) .bx-arrow-back {
+  transform: scaleX(-1);
+}
+
+nz-spin {
+  min-height: 0;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary

- Replaces the blank white page shown when navigating to a non-existent asset (`/gallery/:id`) with proper error/loading states
- Adds **loading spinner** during data fetch, **404 not-found** state with "Back to Gallery" link, and **server error** state with "Retry" button
- Adds subscription cleanup via `takeUntilDestroyed` to prevent memory leaks on component destruction

## Changes

### `asset-details.page.ts`
- Import `HttpErrorResponse`, `DestroyRef`, `takeUntilDestroyed`
- Type `id` parameter as `string` with `?? ''` fallback (was untyped `any`)
- Add `errorState` signal with discriminated union: `'not-found' | 'server-error' | null`
- Guard `ngOnInit()` for missing/empty ID → immediate not-found
- Pipe observable through `takeUntilDestroyed(this.destroyRef)` for cleanup
- Distinguish 404 vs other HTTP errors in error handler
- Add `retryLoad()` method for server-error retry

### `asset-details.page.html`
- Convert to `@if / @else if` chain (loading → not-found → server-error → asset → fallback)
- Loading: spinner + translated message
- Not-found: search icon + title + "Back to Gallery" link (`<a nz-button>`)
- Server error: error icon + title + "Try Again" button
- Fallback `@else`: catches unexpected states with loading spinner
- ARIA: `role="status"` on loading, `role="alert"` on error states (no conflicting `aria-live`)

### `asset-details.page.less`
- Add `.state-container`, `.state-icon`, `.state-title`, `.state-message`, `.state-action-button` styles
- RTL support: `:host-context([dir="rtl"]) .bx-arrow-back { transform: scaleX(-1); }`
- Use CSS variable with fallback for error color: `var(--color-danger-500, #d73a4a)`

### `en.json` / `ar.json`
- Add `UI.BACK_TO_GALLERY` ("Back to Gallery" / "العودة إلى المعرض")
- Add `UI.SOMETHING_WENT_WRONG` ("Something went wrong" / "حدث خطأ ما")

## Test plan

- [ ] Navigate to `/gallery/nonexistent-id` → should show not-found state with search icon and "Back to Gallery" link
- [ ] Navigate to `/gallery/` with no ID → should show not-found state
- [ ] Simulate server error (e.g., disconnect backend) → should show server-error state with "Try Again" button
- [ ] Click "Try Again" → should re-fetch and show content if server recovers
- [ ] Click "Back to Gallery" → should navigate to `/gallery`
- [ ] Navigate to valid asset → should show asset details normally
- [ ] Switch language to Arabic → verify RTL layout, arrow flips, translated messages
- [ ] Navigate away mid-load → no console errors (subscription cleanup working)

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Asset details page now displays specific error states for missing assets and server errors with appropriate messaging
  * Added retry functionality for failed asset loads
  * Added back-to-gallery option when asset is not found
  * Enhanced loading indicators and visual feedback on the asset details view

* **Localization**
  * Added new UI translations for Arabic and English

<!-- end of auto-generated comment: release notes by coderabbit.ai -->