### PR TITLE
fix: add empty and error states to gallery asset listing

### DIFF
--- a/public/i18n/ar.json
+++ b/public/i18n/ar.json
@@ -190,7 +190,10 @@
     "VERSION": "الإصدار",
     "LANGUAGE": "اللغة",
     "VIEWS": "المشاهدات",
-    "CREATED": "تاريخ الإنشاء"
+    "CREATED": "تاريخ الإنشاء",
+    "SOMETHING_WENT_WRONG": "حدث خطأ ما",
+    "NO_RESULTS_MESSAGE": "جرّب تعديل معايير البحث أو الفلترة.",
+    "NO_ASSETS_MESSAGE": "لا توجد أصول متاحة حالياً."
   },
   "CATEGORIES": {
     "mushaf": "المصحف",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -190,7 +190,10 @@
     "VERSION": "Version",
     "LANGUAGE": "Language",
     "VIEWS": "Views",
-    "CREATED": "Created"
+    "CREATED": "Created",
+    "SOMETHING_WENT_WRONG": "Something went wrong",
+    "NO_RESULTS_MESSAGE": "Try adjusting your search or filter criteria.",
+    "NO_ASSETS_MESSAGE": "There are no assets available at the moment."
   },
   "CATEGORIES": {
     "mushaf": "Mushaf",

--- a/src/app/features/gallery/components/assets-listing/assets-listing.component.html
+++ b/src/app/features/gallery/components/assets-listing/assets-listing.component.html
@@ -5,15 +5,41 @@
     (categoriesSelectionChange)="categoriesSelectionChange($event)"
     (licensesSelectionChange)="licensesSelectionChange($event)"
   />
-  <div class="assets-listing__grid" [attr.aria-busy]="loading()">
-    @if (!isServer && loading()) {
-      @for (item of getSkeletonArray(); track item) {
-        <app-asset-card-skeleton />
+
+  @if (errorState()) {
+    <!-- Error State -->
+    <div class="assets-listing__state" role="alert">
+      <i class="bx bx-error-circle assets-listing__state-icon assets-listing__state-icon--error" aria-hidden="true"></i>
+      <h3 class="assets-listing__state-title">{{ 'UI.SOMETHING_WENT_WRONG' | translate }}</h3>
+      <p class="assets-listing__state-message">{{ 'ERRORS.SERVER_ERROR' | translate }}</p>
+      <button nz-button nzType="primary" (click)="getAssets()" [disabled]="loading()">
+        <i class="bx bx-refresh" aria-hidden="true"></i>
+        {{ 'UI.TRY_AGAIN' | translate }}
+      </button>
+    </div>
+  } @else {
+    <div class="assets-listing__grid" [attr.aria-busy]="loading()">
+      @if (!isServer && loading()) {
+        @for (item of getSkeletonArray(); track item) {
+          <app-asset-card-skeleton />
+        }
+      } @else if (assets().length === 0) {
+        <!-- Empty State (spans full grid) -->
+        <div class="assets-listing__state assets-listing__state--in-grid" role="status">
+          <i class="bx bx-search-alt assets-listing__state-icon" aria-hidden="true"></i>
+          @if (hasActiveFilters) {
+            <h3 class="assets-listing__state-title">{{ 'UI.NO_RESULTS_FOUND' | translate }}</h3>
+            <p class="assets-listing__state-message">{{ 'UI.NO_RESULTS_MESSAGE' | translate }}</p>
+          } @else {
+            <h3 class="assets-listing__state-title">{{ 'UI.NO_ASSETS_AVAILABLE' | translate }}</h3>
+            <p class="assets-listing__state-message">{{ 'UI.NO_ASSETS_MESSAGE' | translate }}</p>
+          }
+        </div>
+      } @else {
+        @for (asset of assets(); track asset.id) {
+          <app-asset-card [asset]="asset" />
+        }
       }
-    } @else {
-      @for (asset of assets(); track asset.id) {
-        <app-asset-card [asset]="asset" />
-      }
-    }
-  </div>
+    </div>
+  }
 </div>

--- a/src/app/features/gallery/components/assets-listing/assets-listing.component.less
+++ b/src/app/features/gallery/components/assets-listing/assets-listing.component.less
@@ -40,4 +40,46 @@
       height: 100%;
     }
   }
+
+  // Shared empty & error state
+  &__state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 3rem 1.5rem;
+    min-height: 300px;
+    flex: 3; // match grid flex to fill available width
+
+    // When placed inside the grid, span all columns
+    &--in-grid {
+      grid-column: 1 / -1;
+    }
+  }
+
+  &__state-icon {
+    font-size: 3rem;
+    color: var(--color-neutral-400);
+    margin-bottom: 1rem;
+
+    &--error {
+      color: var(--color-danger-500, #d73a4a);
+    }
+  }
+
+  &__state-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--color-neutral-600);
+    margin: 0 0 0.5rem 0;
+  }
+
+  &__state-message {
+    font-size: 0.875rem;
+    color: var(--color-neutral-400);
+    margin: 0 0 1.25rem 0;
+    max-width: 360px;
+    line-height: 1.6;
+  }
 }

--- a/src/app/features/gallery/components/assets-listing/assets-listing.component.ts
+++ b/src/app/features/gallery/components/assets-listing/assets-listing.component.ts
@@ -1,5 +1,8 @@
 import { isPlatformServer } from '@angular/common';
-import { Component, inject, PLATFORM_ID, signal } from '@angular/core';
+import { Component, DestroyRef, inject, PLATFORM_ID, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TranslateModule } from '@ngx-translate/core';
+import { NzButtonModule } from 'ng-zorro-antd/button';
 import { ViewportService } from '../../../../core/services/viewport.service';
 import { AssetCardSkeletonComponent } from '../../../../shared/components/asset-card-skeleton/asset-card-skeleton.component';
 import { FiltersComponent } from '../../../../shared/components/filters/filters.component';
@@ -10,7 +13,7 @@ import { AssetCardComponent } from '../asset-card/asset-card.component';
 
 @Component({
   selector: 'app-assets-listing',
-  imports: [FiltersComponent, AssetCardComponent, AssetCardSkeletonComponent],
+  imports: [FiltersComponent, AssetCardComponent, AssetCardSkeletonComponent, TranslateModule, NzButtonModule],
   templateUrl: './assets-listing.component.html',
   styleUrl: './assets-listing.component.less',
 })
@@ -18,12 +21,14 @@ export class AssetsListingComponent {
   private readonly assetsService = inject(AssetsService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly viewportService = inject(ViewportService);
+  private readonly destroyRef = inject(DestroyRef);
 
   isServer = isPlatformServer(this.platformId);
   publisherId = getPublisherId();
 
   assets = signal<Asset[]>([]);
   loading = signal<boolean>(false);
+  errorState = signal<boolean>(false);
   categoriesSelection = signal<string[]>([]);
   searchQuery = signal<string>('');
   licensesSelection = signal<string[]>([]);
@@ -42,6 +47,7 @@ export class AssetsListingComponent {
 
   getAssets() {
     this.loading.set(true);
+    this.errorState.set(false);
     this.assetsService
       .getAssets(
         this.categoriesSelection(),
@@ -49,11 +55,24 @@ export class AssetsListingComponent {
         this.licensesSelection(),
         this.publisherId
       )
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response) => this.assets.set(response.results),
         complete: () => this.loading.set(false),
-        error: () => this.loading.set(false),
+        error: () => {
+          this.loading.set(false);
+          this.assets.set([]);
+          this.errorState.set(true);
+        },
       });
+  }
+
+  get hasActiveFilters(): boolean {
+    return (
+      this.searchQuery().trim() !== '' ||
+      this.categoriesSelection().length > 0 ||
+      this.licensesSelection().length > 0
+    );
   }
 
   searchQueryChange(event: string) {


### PR DESCRIPTION
## Summary
- Adds error state with retry button when the assets API fails
- Adds contextual empty state: shows "no results found" when filters are active vs "no assets available" when gallery is genuinely empty
- Fixes subscription leak via `DestroyRef` + `takeUntilDestroyed`
- Clears stale assets on error to prevent leftover data display
- Disables retry button during loading to prevent double-clicks
- Adds `aria-hidden="true"` to decorative Boxicons for accessibility
- Adds bilingual i18n keys (EN + AR) for all new UI messages
- BEM-style responsive CSS for state containers

## Files Changed
- `assets-listing.component.ts` — error signal, subscription cleanup, stale data prevention
- `assets-listing.component.html` — error/empty state templates with a11y roles
- `assets-listing.component.less` — BEM state styles
- `public/i18n/en.json` + `ar.json` — new translation keys

## Test Plan
- [ ] Disconnect network / mock API failure → error state with retry button appears
- [ ] Click retry → loading skeletons, then fresh data
- [ ] Search for nonexistent term → "No results found" empty state
- [ ] Clear all filters with no assets → "No assets available" empty state
- [ ] Verify RTL layout (Arabic) renders correctly
- [ ] Verify decorative icons are hidden from screen readers

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error state handling with a retry button when asset loading fails.
  * Improved empty state messaging to differentiate between "no results" (when filters are active) and "no assets available."

* **Documentation**
  * Added Arabic and English translations for error and empty state messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->