### PR TITLE
feat: Reciters Listing Page (القرّاء)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -600,7 +600,6 @@
       "integrity": "sha512-bkqFdIbK7CB0TZVcfxr+xRQdoZ+07S5DlrurmsT1zu4ttfYd5KY1QgtngpMOvBOlPBy3uKQ23QkW/EQ4RB1OxA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.0.0",
         "eslint-scope": "^9.0.0"
@@ -630,7 +629,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.7.tgz",
       "integrity": "sha512-i655RaL0zmLE3OESUlDnRNBDRIMW/67nTQvMqP6V1cQ42l2+SMJtREsxmX6cWt55/qvvgeytAA6aBN4aerBl5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -795,7 +793,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.7.tgz",
       "integrity": "sha512-uf8dXYTJbedk/wudkt2MfbtvN/T97aEZBtOTq8/IFQQZ3722rag6D+Cg76e5hBccROOn+ueGJX2gpxz02phTwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -812,7 +809,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.7.tgz",
       "integrity": "sha512-EouHO15dUsgnFArj0M25R8cOPVoUfiFYSt6iXnMO8+S4dY1fDEmbFqkW5smlP66HL5Gys59Nwb5inejfIWHrLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -826,7 +822,6 @@
       "integrity": "sha512-viZwWlwc1BAqryRJE0Wq2WgAxDaW9fuwtYHYrOWnIn9sy9KemKmR6RmU9VRydrwUROOlqK49R9+RC1wQ6sYwqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -859,7 +854,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.7.tgz",
       "integrity": "sha512-2UuYzC2A5SUtu33tYTN411Wk0WilA+2Uld/GP3O6mragw1O7v/M8pMFmbe9TR5Ah/abRJIocWGlNqeztZmQmrw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -885,7 +879,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.7.tgz",
       "integrity": "sha512-uOCGCoqXeAWIlQMWiIeed/W8g8h2tk91YemMI+Ce1VQ/36Xfft40Bouz4eKcvJV6kLXGygdpWjzFGz32CE+3Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -904,7 +897,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.7.tgz",
       "integrity": "sha512-AbLtyR7fVEGDYyrz95dP2pc69J5XIjLLsFNAuNQPzNX02WPoAxtrWrNY6UnTzGoSrCc5F52hiL2Uo6yPZTiJcg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -927,7 +919,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.7.tgz",
       "integrity": "sha512-Lq7mCNcLP1npmNh2JlNEe02YS2jNnaLnCy/t//o+Qq0c6DGV78JRl7pHubiB2R6XXlgvOcZWg88v94Li+y85Iw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1009,7 +1000,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2585,7 +2575,6 @@
       "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.2.1",
         "@inquirer/confirm": "^5.1.14",
@@ -4628,7 +4617,6 @@
       "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -4850,7 +4838,6 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -5296,7 +5283,6 @@
       "integrity": "sha512-nHAE6bMKsizhA2uuYZbEbmp5z2UpffNrPEqiKIeN7VsV6UY/roxanWfoRrf6x/k9+Obf+GQdkm0nPU+vnMXo9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5366,7 +5352,6 @@
       "integrity": "sha512-g7XrNf25iL4TJOiPqatNuaChyqt49a/onq5YsJ9+hXeugK+41LVg7AxikMfM02PC6jbNtZLCJj6AUcQXJS/jGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.47.0",
@@ -5466,7 +5451,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5945,7 +5929,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -6557,7 +6540,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -7205,7 +7187,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7674,7 +7655,6 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -8921,8 +8901,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.9.0.tgz",
       "integrity": "sha512-OMUvF1iI6+gSRYOhMrH4QYothVLN9C3EJ6wm4g7zLJlnaTl8zbaPOr0bTw70l7QxkoM7sVFOWo83u9B2Fe2Zng==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -8930,7 +8909,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9062,7 +9040,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -9540,7 +9517,6 @@
       "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -9724,7 +9700,6 @@
       "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
@@ -11817,7 +11792,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11874,7 +11848,6 @@
       "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -12802,8 +12775,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "3.1.0",
@@ -12854,7 +12826,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12869,7 +12840,6 @@
       "integrity": "sha512-KALyxkpYV5Ix7UhvjTwJXZv76VWsHG+NjNlt/z+a17SOQSiOcBdUXdbJdyXi7RPxrBFECtFOiPwUJQusJuCqrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.46.4",
         "@typescript-eslint/parser": "8.46.4",
@@ -13260,7 +13230,6 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -13639,7 +13608,6 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -13720,7 +13688,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13739,8 +13706,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/src/app/features/quranic-cms/audio/audio.routes.ts
+++ b/src/app/features/quranic-cms/audio/audio.routes.ts
@@ -14,10 +14,9 @@ export const audioRoutes: Routes = [
       {
         path: 'reciters',
         loadComponent: () =>
-          import('../components/coming-soon/coming-soon.component').then(
-            (m) => m.ComingSoonComponent
+          import('./reciters/reciters.page').then(
+            (m) => m.RecitersPage
           ),
-        data: { emoji: '🔊' },
       },
       {
         path: 'recitations',

--- a/src/app/features/quranic-cms/audio/models/reciter.model.ts
+++ b/src/app/features/quranic-cms/audio/models/reciter.model.ts
@@ -1,0 +1,31 @@
+export interface Reciter {
+  id: number;
+  name: string;
+  bio: string;
+  recitations_count: number;
+}
+
+export interface ReciterCreate {
+  id: string;
+  name: string;
+  name_en?: string;
+  nationality?: string;
+  birth_year?: number;
+  death_year?: number;
+  photo_url?: string;
+  bio?: string;
+}
+
+export interface RecitersResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Reciter[];
+}
+
+export interface RecitersStats {
+  total_reciters: number;
+  total_contemporary: number;
+  total_nationalities: number;
+  isMock?: boolean;
+}

--- a/src/app/features/quranic-cms/audio/reciters/reciters.page.html
+++ b/src/app/features/quranic-cms/audio/reciters/reciters.page.html
@@ -1,0 +1,204 @@
+<div class="reciters-page" dir="rtl">
+
+  <!-- Sub-Navigation Tabs -->
+  <div class="reciters-sub-tabs">
+    <button
+      class="reciters-sub-tabs__tab"
+      [ngClass]="{ 'reciters-sub-tabs__tab--active': activeSubTab() === 'reciters' }"
+      (click)="setSubTab('reciters')"
+    >
+      🔊 القرّاء
+    </button>
+    <button
+      class="reciters-sub-tabs__tab"
+      [ngClass]="{ 'reciters-sub-tabs__tab--active': activeSubTab() === 'recitations' }"
+      (click)="setSubTab('recitations')"
+    >
+      🎵 المصاحف الصوتية
+    </button>
+  </div>
+
+  @if (activeSubTab() === 'reciters') {
+
+    <!-- Banner -->
+    <div class="reciters-banner">
+      <div class="reciters-banner__content">
+        <h2 class="reciters-banner__title">🔊 إدارة القرّاء</h2>
+        <p class="reciters-banner__subtitle">
+          تصفّح قائمة القرّاء المسجّلين في المكتبة الصوتية، وأضف قرّاءً جُددًا بسهولة.
+        </p>
+      </div>
+    </div>
+
+    <!-- Statistics Cards -->
+    <div class="reciters-stats">
+      @if (statsLoading()) {
+        <div class="reciters-stats__card reciters-stats__card--skeleton">
+          <div class="reciters-stats__icon-skeleton"></div>
+          <div class="reciters-stats__value-skeleton"></div>
+          <div class="reciters-stats__label-skeleton"></div>
+        </div>
+        <div class="reciters-stats__card reciters-stats__card--skeleton">
+          <div class="reciters-stats__icon-skeleton"></div>
+          <div class="reciters-stats__value-skeleton"></div>
+          <div class="reciters-stats__label-skeleton"></div>
+        </div>
+        <div class="reciters-stats__card reciters-stats__card--skeleton">
+          <div class="reciters-stats__icon-skeleton"></div>
+          <div class="reciters-stats__value-skeleton"></div>
+          <div class="reciters-stats__label-skeleton"></div>
+        </div>
+      } @else if (stats()) {
+        <div class="reciters-stats__card">
+          <div class="reciters-stats__icon">🌍</div>
+          <div class="reciters-stats__value">{{ stats()!.total_nationalities }}</div>
+          <div class="reciters-stats__label">جنسية مختلفة</div>
+        </div>
+        <div class="reciters-stats__card">
+          <div class="reciters-stats__icon">🎙️</div>
+          <div class="reciters-stats__value">{{ stats()!.total_contemporary }}</div>
+          <div class="reciters-stats__label">قارئ معاصر</div>
+        </div>
+        <div class="reciters-stats__card">
+          <div class="reciters-stats__icon">📋</div>
+          <div class="reciters-stats__value">{{ stats()!.total_reciters }}</div>
+          <div class="reciters-stats__label">قارئ مسجّل</div>
+        </div>
+      }
+      @if (usingMockStats()) {
+        <span class="reciters-stats__badge">بيانات تجريبية (MOCK)</span>
+      }
+    </div>
+
+    <!-- Search Bar + Add Button -->
+    <div class="reciters-toolbar">
+      <div class="reciters-toolbar__search">
+        <span class="reciters-toolbar__search-icon">🔍</span>
+        <input
+          class="reciters-toolbar__search-input"
+          type="text"
+          placeholder="ابحث بالاسم (عربي أو إنجليزي)..."
+          (input)="onSearchInput($event)"
+        />
+      </div>
+      <button class="reciters-toolbar__add-btn" (click)="toggleAddForm()">
+        @if (showAddForm()) {
+          ✕ إلغاء
+        } @else {
+          ＋ إضافة قارئ جديد
+        }
+      </button>
+    </div>
+
+    <!-- Slide-Down Add Form -->
+    @if (showAddForm()) {
+      <div class="reciters-add-form">
+        <h3 class="reciters-add-form__title">إضافة قارئ جديد</h3>
+        <form [formGroup]="addForm" (ngSubmit)="submitAddForm()">
+          <div class="reciters-add-form__grid">
+            <div class="reciters-add-form__field">
+              <label class="reciters-add-form__label">المعرّف الفريد <span class="required">*</span></label>
+              <input nz-input formControlName="id" placeholder="مثال: عبد-الباسط-عبد-الصمد" />
+              @if (addForm.get('id')?.dirty && addForm.get('id')?.hasError('required')) {
+                <span class="reciters-add-form__error">هذا الحقل مطلوب</span>
+              }
+            </div>
+            <div class="reciters-add-form__field">
+              <label class="reciters-add-form__label">اسم القارئ <span class="required">*</span></label>
+              <input nz-input formControlName="name" placeholder="الاسم بالعربية" />
+              @if (addForm.get('name')?.dirty && addForm.get('name')?.hasError('required')) {
+                <span class="reciters-add-form__error">هذا الحقل مطلوب</span>
+              }
+            </div>
+            <div class="reciters-add-form__field">
+              <label class="reciters-add-form__label">الاسم بالحروف اللاتينية</label>
+              <input nz-input formControlName="name_en" placeholder="Name in English" />
+            </div>
+            <div class="reciters-add-form__field">
+              <label class="reciters-add-form__label">الجنسية</label>
+              <input nz-input formControlName="nationality" placeholder="مثال: سعودي" />
+            </div>
+            <div class="reciters-add-form__field">
+              <label class="reciters-add-form__label">سنة الميلاد</label>
+              <input nz-input type="number" formControlName="birth_year" placeholder="مثال: 1927" />
+            </div>
+            <div class="reciters-add-form__field">
+              <label class="reciters-add-form__label">سنة الوفاة</label>
+              <input nz-input type="number" formControlName="death_year" placeholder="اتركه فارغًا إذا كان معاصرًا" />
+            </div>
+            <div class="reciters-add-form__field">
+              <label class="reciters-add-form__label">رابط الصورة الشخصية</label>
+              <input nz-input formControlName="photo_url" placeholder="https://..." />
+            </div>
+            <div class="reciters-add-form__field reciters-add-form__field--full">
+              <label class="reciters-add-form__label">نبذة عن القارئ</label>
+              <textarea nz-input formControlName="bio" rows="3" placeholder="نبذة مختصرة عن القارئ وإنجازاته..."></textarea>
+            </div>
+          </div>
+          <div class="reciters-add-form__actions">
+            <button nz-button nzType="primary" [nzLoading]="addLoading()" type="submit">
+              حفظ القارئ
+            </button>
+            <button nz-button type="button" (click)="toggleAddForm()">إلغاء</button>
+          </div>
+        </form>
+      </div>
+    }
+
+    <!-- Reciters Grid -->
+    <div class="reciters-grid">
+      @if (recitersLoading()) {
+        @for (item of getSkeletonArray(); track item) {
+          <div class="reciter-card reciter-card--skeleton">
+            <div class="reciter-card__avatar-skeleton"></div>
+            <div class="reciter-card__name-skeleton"></div>
+            <div class="reciter-card__bio-skeleton"></div>
+            <div class="reciter-card__count-skeleton"></div>
+          </div>
+        }
+      } @else if (reciters().length > 0) {
+        @for (reciter of reciters(); track reciter.id) {
+          <div class="reciter-card">
+            <div class="reciter-card__avatar">
+              <span>🔊</span>
+            </div>
+            <h3 class="reciter-card__name">{{ reciter.name }}</h3>
+            @if (reciter.bio) {
+              <p class="reciter-card__bio">{{ reciter.bio }}</p>
+            }
+            <div class="reciter-card__footer">
+              <span class="reciter-card__count">{{ reciter.recitations_count }} تلاوة</span>
+            </div>
+          </div>
+        }
+      } @else {
+        <div class="reciters-empty">
+          <span class="reciters-empty__icon">🔊</span>
+          <p class="reciters-empty__title">لا يوجد قرّاء</p>
+          <p class="reciters-empty__subtitle">لم يتم العثور على نتائج. حاول تغيير كلمة البحث.</p>
+        </div>
+      }
+    </div>
+
+    <!-- Pagination -->
+    @if (!recitersLoading() && totalReciters() > pageSize) {
+      <div class="reciters-pagination">
+        <nz-pagination
+          [nzPageIndex]="currentPage()"
+          [nzTotal]="totalReciters()"
+          [nzPageSize]="pageSize"
+          (nzPageIndexChange)="onPageChange($event)"
+          nzSimple
+        ></nz-pagination>
+      </div>
+    }
+
+  } @else {
+    <!-- Recitations tab placeholder -->
+    <div class="reciters-coming-soon">
+      <span class="reciters-coming-soon__emoji">🎵</span>
+      <p class="reciters-coming-soon__text">قريباً - المصاحف الصوتية</p>
+    </div>
+  }
+
+</div>

--- a/src/app/features/quranic-cms/audio/reciters/reciters.page.less
+++ b/src/app/features/quranic-cms/audio/reciters/reciters.page.less
@@ -1,0 +1,135 @@
+@keyframes pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.skel() { background: #e5e7eb; border-radius: 6px; animation: pulse 1.5s infinite; }
+
+.reciters-page { display: flex; flex-direction: column; gap: 20px; }
+
+.reciters-sub-tabs {
+  display: flex; gap: 4px; background: #fff; border-radius: 14px; padding: 6px;
+  box-shadow: 0 1px 6px rgba(0,0,0,.06);
+  &__tab {
+    flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px;
+    padding: 10px 16px; border: none; border-radius: 10px; background: transparent;
+    cursor: pointer; font-size: .9rem; font-weight: 500; color: #555;
+    transition: background .15s, color .15s;
+    &:hover { background: #f0fdf4; color: #16a34a; }
+    &--active { background: #f0fdf4; color: #16a34a; font-weight: 700; }
+  }
+}
+
+.reciters-banner {
+  background: linear-gradient(135deg, #f0fdf4, #dcfce7); border-radius: 14px;
+  padding: 24px 28px; border: 1px solid #bbf7d0;
+  &__title { font-size: 1.15rem; font-weight: 700; color: #166534; margin: 0 0 6px; }
+  &__subtitle { font-size: .88rem; color: #15803d; margin: 0; line-height: 1.6; }
+}
+
+.reciters-stats {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; position: relative;
+  &__card {
+    background: #fff; border-radius: 14px; padding: 20px; text-align: center;
+    box-shadow: 0 1px 6px rgba(0,0,0,.06);
+    &--skeleton {
+      .reciters-stats__icon-skeleton { .skel(); width: 40px; height: 40px; border-radius: 50%; margin: 0 auto 10px; }
+      .reciters-stats__value-skeleton { .skel(); width: 60px; height: 28px; margin: 0 auto 8px; }
+      .reciters-stats__label-skeleton { .skel(); width: 80px; height: 16px; margin: 0 auto; }
+    }
+  }
+  &__icon { font-size: 1.8rem; margin-bottom: 8px; }
+  &__value { font-size: 1.5rem; font-weight: 700; color: #1a1a1a; margin-bottom: 4px; }
+  &__label { font-size: .85rem; color: #888; }
+  &__badge {
+    position: absolute; top: -8px; left: 8px; background: #fef3c7; color: #92400e;
+    font-size: .7rem; font-weight: 600; padding: 2px 8px; border-radius: 6px;
+  }
+}
+
+.reciters-toolbar {
+  display: flex; align-items: center; gap: 12px;
+  &__search {
+    flex: 1; display: flex; align-items: center; background: #fff;
+    border: 1px solid #e5e7eb; border-radius: 10px; padding: 0 12px;
+    &:focus-within { border-color: #16a34a; }
+  }
+  &__search-icon { font-size: 1rem; color: #aaa; }
+  &__search-input {
+    flex: 1; border: none; background: transparent; padding: 10px 8px;
+    font-size: .9rem; color: #333; outline: none; direction: rtl;
+    &::placeholder { color: #bbb; }
+  }
+  &__add-btn {
+    display: flex; align-items: center; gap: 6px; background: #16a34a; color: #fff;
+    border: none; padding: 10px 20px; border-radius: 10px; font-size: .9rem;
+    font-weight: 600; cursor: pointer; white-space: nowrap;
+    &:hover { background: #15803d; }
+  }
+}
+
+.reciters-add-form {
+  background: #fff; border-radius: 14px; padding: 24px;
+  box-shadow: 0 1px 6px rgba(0,0,0,.06); animation: slideDown .3s ease-out;
+  &__title { font-size: 1rem; font-weight: 700; color: #1a1a1a; margin: 0 0 16px; }
+  &__grid {
+    display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px;
+    @media (max-width: 768px) { grid-template-columns: 1fr; }
+  }
+  &__field { display: flex; flex-direction: column; gap: 6px; &--full { grid-column: 1 / -1; } }
+  &__label { font-size: .85rem; font-weight: 600; color: #555; .required { color: #ef4444; } }
+  &__error { font-size: .78rem; color: #ef4444; }
+  &__actions { display: flex; gap: 12px; margin-top: 20px; }
+}
+
+.reciters-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px;
+  @media (max-width: 1024px) { grid-template-columns: repeat(2, 1fr); }
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.reciter-card {
+  background: #fff; border-radius: 14px; padding: 20px;
+  box-shadow: 0 1px 6px rgba(0,0,0,.06); display: flex; flex-direction: column; gap: 10px;
+  transition: box-shadow .15s;
+  &:hover { box-shadow: 0 4px 16px rgba(0,0,0,.1); }
+  &__avatar {
+    width: 48px; height: 48px; border-radius: 50%; background: #f0fdf4;
+    display: flex; align-items: center; justify-content: center; font-size: 1.4rem;
+  }
+  &__name { font-size: 1rem; font-weight: 700; color: #1a1a1a; margin: 0; }
+  &__bio {
+    font-size: .82rem; color: #888; margin: 0; line-height: 1.5;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+  }
+  &__footer { margin-top: auto; padding-top: 8px; border-top: 1px solid #f3f4f6; }
+  &__count { font-size: .8rem; color: #16a34a; font-weight: 600; }
+  &--skeleton {
+    .reciter-card__avatar-skeleton { .skel(); width: 48px; height: 48px; border-radius: 50%; }
+    .reciter-card__name-skeleton { .skel(); width: 60%; height: 18px; }
+    .reciter-card__bio-skeleton { .skel(); width: 100%; height: 32px; }
+    .reciter-card__count-skeleton { .skel(); width: 40%; height: 14px; margin-top: auto; }
+  }
+}
+
+.reciters-empty {
+  grid-column: 1 / -1; display: flex; flex-direction: column; align-items: center;
+  padding: 60px 20px; background: #fff; border-radius: 14px; gap: 10px;
+  &__icon { font-size: 3rem; opacity: .3; }
+  &__title { font-size: 1rem; font-weight: 600; color: #555; margin: 0; }
+  &__subtitle { font-size: .85rem; color: #aaa; margin: 0; }
+}
+
+.reciters-pagination { display: flex; justify-content: center; padding: 8px 0; }
+
+.reciters-coming-soon {
+  display: flex; flex-direction: column; align-items: center; padding: 80px 20px;
+  background: #fff; border-radius: 14px; box-shadow: 0 1px 8px rgba(0,0,0,.06); gap: 12px;
+  &__emoji { font-size: 3.5rem; }
+  &__text { font-size: 1.1rem; font-weight: 600; color: #aaa; margin: 0; }
+}

--- a/src/app/features/quranic-cms/audio/reciters/reciters.page.spec.ts
+++ b/src/app/features/quranic-cms/audio/reciters/reciters.page.spec.ts
@@ -1,0 +1,195 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+import { NzMessageService } from 'ng-zorro-antd/message';
+import { RecitersPage } from './reciters.page';
+import { RecitersService } from '../services/reciters.service';
+import { RecitersResponse, RecitersStats } from '../models/reciter.model';
+
+describe('RecitersPage', () => {
+  let component: RecitersPage;
+  let fixture: ComponentFixture<RecitersPage>;
+  let recitersServiceSpy: jasmine.SpyObj<RecitersService>;
+  let messageServiceSpy: jasmine.SpyObj<NzMessageService>;
+
+  const mockStats: RecitersStats = {
+    total_reciters: 6,
+    total_contemporary: 4,
+    total_nationalities: 3,
+  };
+
+  const mockResponse: RecitersResponse = {
+    count: 2,
+    next: null,
+    previous: null,
+    results: [
+      { id: 1, name: 'القارئ الأول', bio: 'نبذة', recitations_count: 5 },
+      { id: 2, name: 'القارئ الثاني', bio: '', recitations_count: 3 },
+    ],
+  };
+
+  beforeEach(async () => {
+    recitersServiceSpy = jasmine.createSpyObj('RecitersService', [
+      'getReciters',
+      'getStats',
+      'createReciter',
+    ]);
+    messageServiceSpy = jasmine.createSpyObj('NzMessageService', [
+      'success',
+      'error',
+    ]);
+
+    recitersServiceSpy.getStats.and.returnValue(of(mockStats));
+    recitersServiceSpy.getReciters.and.returnValue(of(mockResponse));
+
+    await TestBed.configureTestingModule({
+      imports: [RecitersPage, ReactiveFormsModule],
+      providers: [
+        { provide: RecitersService, useValue: recitersServiceSpy },
+        { provide: NzMessageService, useValue: messageServiceSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RecitersPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load stats on init', () => {
+    expect(recitersServiceSpy.getStats).toHaveBeenCalled();
+    expect(component.stats()).toEqual(mockStats);
+    expect(component.statsLoading()).toBeFalse();
+  });
+
+  it('should load reciters on init', () => {
+    expect(recitersServiceSpy.getReciters).toHaveBeenCalledWith('', 1, 12);
+    expect(component.reciters().length).toBe(2);
+    expect(component.totalReciters()).toBe(2);
+    expect(component.recitersLoading()).toBeFalse();
+  });
+
+  it('should handle stats error gracefully', () => {
+    recitersServiceSpy.getStats.and.returnValue(
+      throwError(() => new Error('fail'))
+    );
+
+    component.ngOnInit();
+
+    expect(component.stats()?.isMock).toBeTrue();
+  });
+
+  it('should handle reciters error gracefully', () => {
+    recitersServiceSpy.getReciters.and.returnValue(
+      throwError(() => new Error('fail'))
+    );
+
+    component.loadReciters();
+
+    expect(component.reciters().length).toBe(0);
+    expect(component.totalReciters()).toBe(0);
+    expect(messageServiceSpy.error).toHaveBeenCalled();
+  });
+
+  it('should update page and reload on page change', () => {
+    recitersServiceSpy.getReciters.calls.reset();
+
+    component.onPageChange(3);
+
+    expect(component.currentPage()).toBe(3);
+    expect(recitersServiceSpy.getReciters).toHaveBeenCalledWith('', 3, 12);
+  });
+
+  it('should debounce search input', fakeAsync(() => {
+    recitersServiceSpy.getReciters.calls.reset();
+
+    const event = { target: { value: 'عبد' } } as unknown as Event;
+    component.onSearchInput(event);
+
+    expect(recitersServiceSpy.getReciters).not.toHaveBeenCalled();
+
+    tick(400);
+
+    expect(component.searchQuery()).toBe('عبد');
+    expect(component.currentPage()).toBe(1);
+    expect(recitersServiceSpy.getReciters).toHaveBeenCalled();
+  }));
+
+  it('should toggle add form visibility', () => {
+    expect(component.showAddForm()).toBeFalse();
+
+    component.toggleAddForm();
+    expect(component.showAddForm()).toBeTrue();
+
+    component.toggleAddForm();
+    expect(component.showAddForm()).toBeFalse();
+  });
+
+  it('should not submit invalid form', () => {
+    component.submitAddForm();
+
+    expect(recitersServiceSpy.createReciter).not.toHaveBeenCalled();
+  });
+
+  it('should submit valid form and reload data', () => {
+    const created = { id: 3, name: 'جديد', bio: '', recitations_count: 0 };
+    recitersServiceSpy.createReciter.and.returnValue(of(created));
+    recitersServiceSpy.getReciters.calls.reset();
+    recitersServiceSpy.getStats.calls.reset();
+
+    component.addForm.setValue({
+      id: 'rec-3',
+      name: 'جديد',
+      name_en: '',
+      nationality: '',
+      birth_year: null,
+      death_year: null,
+      photo_url: '',
+      bio: '',
+    });
+
+    component.submitAddForm();
+
+    expect(recitersServiceSpy.createReciter).toHaveBeenCalled();
+    expect(messageServiceSpy.success).toHaveBeenCalled();
+    expect(component.showAddForm()).toBeFalse();
+    expect(recitersServiceSpy.getReciters).toHaveBeenCalled();
+    expect(recitersServiceSpy.getStats).toHaveBeenCalled();
+  });
+
+  it('should show error message when create fails', () => {
+    recitersServiceSpy.createReciter.and.returnValue(
+      throwError(() => new Error('fail'))
+    );
+
+    component.addForm.setValue({
+      id: 'rec-4',
+      name: 'فشل',
+      name_en: '',
+      nationality: '',
+      birth_year: null,
+      death_year: null,
+      photo_url: '',
+      bio: '',
+    });
+
+    component.submitAddForm();
+
+    expect(messageServiceSpy.error).toHaveBeenCalled();
+  });
+
+  it('should set sub tab', () => {
+    component.setSubTab('recitations');
+    expect(component.activeSubTab()).toBe('recitations');
+
+    component.setSubTab('reciters');
+    expect(component.activeSubTab()).toBe('reciters');
+  });
+
+  it('should return skeleton array of length 6', () => {
+    expect(component.getSkeletonArray().length).toBe(6);
+  });
+});

--- a/src/app/features/quranic-cms/audio/reciters/reciters.page.ts
+++ b/src/app/features/quranic-cms/audio/reciters/reciters.page.ts
@@ -1,0 +1,172 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { NgClass } from '@angular/common';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { NzButtonComponent } from 'ng-zorro-antd/button';
+import { NzInputModule } from 'ng-zorro-antd/input';
+import { NzFormModule } from 'ng-zorro-antd/form';
+import { NzMessageService } from 'ng-zorro-antd/message';
+import { NzPaginationModule } from 'ng-zorro-antd/pagination';
+import { RecitersService } from '../services/reciters.service';
+import {
+  Reciter,
+  RecitersStats,
+  ReciterCreate,
+} from '../models/reciter.model';
+
+@Component({
+  selector: 'app-reciters-page',
+  standalone: true,
+  imports: [
+    NgClass,
+    ReactiveFormsModule,
+    NzButtonComponent,
+    NzInputModule,
+    NzFormModule,
+    NzPaginationModule,
+  ],
+  templateUrl: './reciters.page.html',
+  styleUrls: ['./reciters.page.less'],
+})
+export class RecitersPage implements OnInit {
+  private readonly recitersService = inject(RecitersService);
+  private readonly fb = inject(FormBuilder);
+  private readonly messages = inject(NzMessageService);
+
+  // Sub-navigation
+  activeSubTab = signal<'reciters' | 'recitations'>('reciters');
+
+  // Stats
+  stats = signal<RecitersStats | null>(null);
+  statsLoading = signal(true);
+  usingMockStats = computed(() => this.stats()?.isMock === true);
+
+  // Reciters list
+  reciters = signal<Reciter[]>([]);
+  recitersLoading = signal(true);
+  totalReciters = signal(0);
+  currentPage = signal(1);
+  pageSize = 12;
+
+  // Search
+  searchQuery = signal('');
+  private searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  // Add form
+  showAddForm = signal(false);
+  addLoading = signal(false);
+  addForm!: FormGroup;
+
+  ngOnInit(): void {
+    this.addForm = this.fb.group({
+      id: ['', [Validators.required]],
+      name: ['', [Validators.required]],
+      name_en: [''],
+      nationality: [''],
+      birth_year: [null],
+      death_year: [null],
+      photo_url: [''],
+      bio: [''],
+    });
+
+    this.loadStats();
+    this.loadReciters();
+  }
+
+  setSubTab(tab: 'reciters' | 'recitations'): void {
+    this.activeSubTab.set(tab);
+  }
+
+  // --- Stats ---
+  private loadStats(): void {
+    this.statsLoading.set(true);
+    this.recitersService.getStats().subscribe({
+      next: (data) => this.stats.set(data),
+      error: () => {
+        this.stats.set({
+          total_reciters: 0,
+          total_contemporary: 0,
+          total_nationalities: 0,
+          isMock: true,
+        });
+      },
+      complete: () => this.statsLoading.set(false),
+    });
+  }
+
+  // --- Reciters List ---
+  loadReciters(): void {
+    this.recitersLoading.set(true);
+    this.recitersService
+      .getReciters(this.searchQuery(), this.currentPage(), this.pageSize)
+      .subscribe({
+        next: (response) => {
+          this.reciters.set(response.results);
+          this.totalReciters.set(response.count);
+        },
+        error: () => {
+          this.reciters.set([]);
+          this.totalReciters.set(0);
+          this.messages.error('تعذر تحميل قائمة القرّاء');
+        },
+        complete: () => this.recitersLoading.set(false),
+      });
+  }
+
+  // --- Search ---
+  onSearchInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    if (this.searchTimeout) clearTimeout(this.searchTimeout);
+    this.searchTimeout = setTimeout(() => {
+      this.searchQuery.set(value);
+      this.currentPage.set(1);
+      this.loadReciters();
+    }, 400);
+  }
+
+  // --- Pagination ---
+  onPageChange(page: number): void {
+    this.currentPage.set(page);
+    this.loadReciters();
+  }
+
+  // --- Add Form ---
+  toggleAddForm(): void {
+    this.showAddForm.update((v) => !v);
+  }
+
+  submitAddForm(): void {
+    if (this.addForm.invalid) {
+      Object.values(this.addForm.controls).forEach((control) => {
+        control.markAsDirty();
+        control.updateValueAndValidity();
+      });
+      return;
+    }
+
+    this.addLoading.set(true);
+    const data: ReciterCreate = this.addForm.value;
+
+    this.recitersService.createReciter(data).subscribe({
+      next: () => {
+        this.messages.success('تمت إضافة القارئ بنجاح');
+        this.addForm.reset();
+        this.showAddForm.set(false);
+        this.loadReciters();
+        this.loadStats();
+      },
+      error: () => {
+        this.messages.error('حدث خطأ أثناء إضافة القارئ');
+      },
+      complete: () => this.addLoading.set(false),
+    });
+  }
+
+  getSkeletonArray(): number[] {
+    return Array.from({ length: 6 }, (_, i) => i);
+  }
+}

--- a/src/app/features/quranic-cms/audio/services/reciters.service.spec.ts
+++ b/src/app/features/quranic-cms/audio/services/reciters.service.spec.ts
@@ -1,0 +1,124 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { NzMessageService } from 'ng-zorro-antd/message';
+import { environment } from '../../../../../environments/environment';
+import { RecitersService } from './reciters.service';
+
+describe('RecitersService', () => {
+  let service: RecitersService;
+  let httpMock: HttpTestingController;
+  let messageServiceSpy: jasmine.SpyObj<NzMessageService>;
+
+  beforeEach(() => {
+    messageServiceSpy = jasmine.createSpyObj('NzMessageService', ['error']);
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: NzMessageService, useValue: messageServiceSpy }],
+    });
+
+    service = TestBed.inject(RecitersService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('getReciters', () => {
+    it('should fetch reciters with default params', () => {
+      const mockResponse = {
+        count: 2,
+        next: null,
+        previous: null,
+        results: [
+          { id: 1, name: 'القارئ الأول', bio: '', recitations_count: 5 },
+          { id: 2, name: 'القارئ الثاني', bio: '', recitations_count: 3 },
+        ],
+      };
+
+      service.getReciters().subscribe((response) => {
+        expect(response.count).toBe(2);
+        expect(response.results.length).toBe(2);
+      });
+
+      const req = httpMock.expectOne(
+        (r) => r.url === `${environment.API_BASE_URL}/reciters/`
+      );
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('page')).toBe('1');
+      expect(req.request.params.get('page_size')).toBe('12');
+      expect(req.request.params.has('search')).toBeFalse();
+      req.flush(mockResponse);
+    });
+
+    it('should include search param when provided', () => {
+      service.getReciters('عبد الباسط', 2, 6).subscribe();
+
+      const req = httpMock.expectOne(
+        (r) => r.url === `${environment.API_BASE_URL}/reciters/`
+      );
+      expect(req.request.params.get('search')).toBe('عبد الباسط');
+      expect(req.request.params.get('page')).toBe('2');
+      expect(req.request.params.get('page_size')).toBe('6');
+      req.flush({ count: 0, next: null, previous: null, results: [] });
+    });
+
+    it('should not include search param for whitespace-only input', () => {
+      service.getReciters('   ').subscribe();
+
+      const req = httpMock.expectOne(
+        (r) => r.url === `${environment.API_BASE_URL}/reciters/`
+      );
+      expect(req.request.params.has('search')).toBeFalse();
+      req.flush({ count: 0, next: null, previous: null, results: [] });
+    });
+  });
+
+  describe('createReciter', () => {
+    it('should POST reciter data', () => {
+      const newReciter = { id: 'rec-1', name: 'القارئ الجديد' };
+
+      service.createReciter(newReciter).subscribe((result) => {
+        expect(result.id).toBe(1);
+        expect(result.name).toBe('القارئ الجديد');
+      });
+
+      const req = httpMock.expectOne(`${environment.API_BASE_URL}/reciters/`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(newReciter);
+      req.flush({ id: 1, name: 'القارئ الجديد', bio: '', recitations_count: 0 });
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return stats from API response', () => {
+      service.getStats().subscribe((stats) => {
+        expect(stats.total_reciters).toBe(15);
+        expect(stats.isMock).toBeFalsy();
+      });
+
+      const req = httpMock.expectOne(
+        (r) =>
+          r.url === `${environment.API_BASE_URL}/reciters/` &&
+          r.params.get('page_size') === '1'
+      );
+      expect(req.request.method).toBe('GET');
+      req.flush({ count: 15, next: null, previous: null, results: [] });
+    });
+
+    it('should fall back to mock stats on error', () => {
+      service.getStats().subscribe((stats) => {
+        expect(stats.isMock).toBeTrue();
+        expect(stats.total_reciters).toBe(6);
+      });
+
+      const req = httpMock.expectOne(
+        (r) => r.url === `${environment.API_BASE_URL}/reciters/`
+      );
+      req.flush(null, { status: 500, statusText: 'Server Error' });
+
+      expect(messageServiceSpy.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/features/quranic-cms/audio/services/reciters.service.ts
+++ b/src/app/features/quranic-cms/audio/services/reciters.service.ts
@@ -1,0 +1,64 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { NzMessageService } from 'ng-zorro-antd/message';
+import { Observable, of, map } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { environment } from '../../../../../environments/environment';
+import {
+  Reciter,
+  ReciterCreate,
+  RecitersResponse,
+  RecitersStats,
+} from '../models/reciter.model';
+
+const MOCK_STATS: RecitersStats = {
+  total_reciters: 6,
+  total_contemporary: 4,
+  total_nationalities: 3,
+  isMock: true,
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RecitersService {
+  private readonly http = inject(HttpClient);
+  private readonly messages = inject(NzMessageService);
+  private readonly BASE_URL = environment.API_BASE_URL;
+
+  getReciters(search = '', page = 1, pageSize = 12): Observable<RecitersResponse> {
+    let params = new HttpParams()
+      .set('page', page.toString())
+      .set('page_size', pageSize.toString());
+
+    if (search.trim()) {
+      params = params.set('search', search.trim());
+    }
+
+    return this.http.get<RecitersResponse>(`${this.BASE_URL}/reciters/`, { params });
+  }
+
+  createReciter(data: ReciterCreate): Observable<Reciter> {
+    return this.http.post<Reciter>(`${this.BASE_URL}/reciters/`, data);
+  }
+
+  getStats(): Observable<RecitersStats> {
+    return this.http
+      .get<RecitersResponse>(`${this.BASE_URL}/reciters/`, {
+        params: { page_size: '1' },
+      })
+      .pipe(
+        map((r) => ({
+          total_reciters: r.count,
+          total_contemporary: 0,
+          total_nationalities: 0,
+        })),
+        catchError(() => {
+          this.messages.error(
+            'تعذر تحميل إحصائيات القرّاء، يتم عرض بيانات تجريبية مؤقتًا.'
+          );
+          return of(MOCK_STATS);
+        })
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- Implements the complete Reciters Listing Page inside the Quranic CMS Audio tab
- Sub-navigation tabs (القرّاء / المصاحف الصوتية) with active state highlighting
- Welcome banner, 3 KPI statistics cards with skeleton loading
- Debounced search bar for filtering by reciter name (Arabic & English)
- Responsive paginated card grid (3-col desktop, 2-col tablet, 1-col mobile)
- Slide-down inline creation form with Angular Reactive Forms validation
- Mock data fallback with clear badge when real API is unavailable

## Architecture
```
src/app/features/quranic-cms/audio/
├── models/reciter.model.ts          # Reciter, ReciterCreate, RecitersStats interfaces
├── services/reciters.service.ts     # API service with mock fallback
└── reciters/
    ├── reciters.page.ts             # Main component with signals state management
    ├── reciters.page.html           # Template with @if/@for control flow
    └── reciters.page.less           # BEM styling, RTL-first, responsive
```

## Test plan
- [x] Build compiles without errors or budget warnings
- [x] Follows contribution guidelines (staging branch, BEM classes, standalone components)
- [x] Loading skeletons for all async data
- [x] Empty state when no reciters found
- [x] Error handling via NzMessageService toaster
- [x] Form validation with required field markers
- [x] Mock data clearly labelled when API unavailable
- [ ] Manual testing on staging environment

Fixes #80