### PR TITLE
fix(auth): use correct field name is_profile_completed in updateProfile

### DIFF
--- a/src/app/core/auth/services/auth.service.ts
+++ b/src/app/core/auth/services/auth.service.ts
@@ -161,7 +161,7 @@ export class AuthService {
           if (currentUser && response.is_profile_completed) {
             const updatedUser = {
               ...currentUser,
-              profile_completed: response.is_profile_completed,
+              is_profile_completed: response.is_profile_completed,
               ...profileData,
             };
             this.currentUser.set(updatedUser);


### PR DESCRIPTION
## ماذا يفعل هذا الـ PR؟

إصلاح خطأ في اسم الحقل عند تحديث بيانات المستخدم بعد إكمال الملف الشخصي.

## المشكلة

في `auth.service.ts`، دالة `updateProfile()` كانت تحفظ حالة إكمال الملف الشخصي تحت المفتاح `profile_completed` بدلاً من `is_profile_completed` المُعرّف في واجهة `User`.

هذا يعني أنه بعد إكمال الملف الشخصي:
- المفتاح `is_profile_completed` يبقى بقيمته القديمة (`false`)
- حراسة `profileCompletedGuard` تتحقق من `user?.is_profile_completed` فتجده `false`
- المستخدم يُعاد توجيهه لصفحة إكمال الملف الشخصي رغم أنه أكمله بالفعل

## التغيير

```diff
- profile_completed: response.is_profile_completed,
+ is_profile_completed: response.is_profile_completed,
```

## الاختبار

- تتبعت تدفق البيانات من `updateProfile()` → `currentUser signal` → `setUser()` → `profileCompletedGuard`
- تأكدت أن واجهة `User` تستخدم `is_profile_completed` (سطر 30 في `auth.model.ts`)
- تأكدت أن `profileCompletedGuard` يتحقق من `user?.is_profile_completed` (سطر 28)
- البناء يعمل بنجاح بدون أخطاء

## المهمة المرتبطة

Closes #100