### PR TITLE
fix(a11y): associate label with search input in search-panel

### DIFF
--- a/src/app/features/quranic-cms/components/search-panel/search-panel.component.html
+++ b/src/app/features/quranic-cms/components/search-panel/search-panel.component.html
@@ -1,10 +1,11 @@
 <div class="qcms-search-panel">
   <h2 class="qcms-search-panel__title">البحث في القرآن الكريم</h2>
   <p class="qcms-search-panel__subtitle">ابحث عن كلمة أو عبارة لعرض جميع الآيات التي تحتوي عليها</p>
-  <label class="qcms-search-panel__label">أدخل كلمة أو عبارة للبحث</label>
+  <label class="qcms-search-panel__label" for="quran-search-input">أدخل كلمة أو عبارة للبحث</label>
   <div class="qcms-search-panel__input-row">
     <span class="qcms-search-panel__search-icon">🔍</span>
     <input
+      id="quran-search-input"
       class="qcms-search-panel__input"
       type="text"
       placeholder="مثال: الله، الرحمن، الصلاة..."


### PR DESCRIPTION
## ماذا يفعل هذا الـ PR؟

ربط عنصر `<label>` بحقل `<input>` في مكون البحث عبر خاصيتي `for` و `id`.

## المشكلة

عنصر `<label>` في مكون `search-panel` لم يكن مرتبطاً بحقل الإدخال، مما يسبب:
- قارئات الشاشة لا تستطيع ربط التسمية بالحقل
- خطأ ESLint: `A label component must be associated with a form element`
- الضغط على التسمية لا ينقل التركيز لحقل الإدخال

## التغيير

```html
<!-- قبل -->
<label class="qcms-search-panel__label">أدخل كلمة أو عبارة للبحث</label>
<input class="qcms-search-panel__input" type="text" ... />

<!-- بعد -->
<label class="qcms-search-panel__label" for="quran-search-input">أدخل كلمة أو عبارة للبحث</label>
<input id="quran-search-input" class="qcms-search-panel__input" type="text" ... />
```

## الاختبار

- البناء يعمل بنجاح بدون أخطاء
- خطأ ESLint `label-has-associated-control` لم يعد يظهر لهذا الملف
- الضغط على التسمية ينقل التركيز لحقل البحث

## المهمة المرتبطة

Closes #102