### PR TITLE
fix(publishers): improve type safety and migrate to built-in control flow

### DIFF
--- a/src/app/features/quranic-cms/publishers/components/publisher-add/publisher-add.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publisher-add/publisher-add.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { NzButtonModule } from 'ng-zorro-antd/button';
@@ -13,7 +12,6 @@ import { PublishersService } from '../../services/publishers.service';
   selector: 'app-publisher-add',
   standalone: true,
   imports: [
-    CommonModule,
     ReactiveFormsModule,
     NzFormModule,
     NzInputModule,
@@ -22,14 +20,17 @@ import { PublishersService } from '../../services/publishers.service';
     NzIconModule,
   ],
   template: `
-    <div *ngIf="!isAdding" class="add-button-container">
-      <button nz-button nzType="primary" (click)="showForm()" class="add-btn">
-        <span nz-icon nzType="plus"></span>
-        إضافة ناشر جديد
-      </button>
-    </div>
+    @if (!isAdding) {
+      <div class="add-button-container">
+        <button nz-button nzType="primary" (click)="showForm()" class="add-btn">
+          <span nz-icon nzType="plus"></span>
+          إضافة ناشر جديد
+        </button>
+      </div>
+    }
 
-    <div *ngIf="isAdding" class="form-page-wrapper">
+    @if (isAdding) {
+    <div class="form-page-wrapper">
       <div class="inline-form-card">
         <div class="form-header">
           <h2 class="form-title">إضافة ناشر جديد</h2>
@@ -160,6 +161,7 @@ import { PublishersService } from '../../services/publishers.service';
         </form>
       </div>
     </div>
+    }
   `,
   styles: [
     `

--- a/src/app/features/quranic-cms/publishers/components/publishers-stats-cards/publishers-stats-cards.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publishers-stats-cards/publishers-stats-cards.component.ts
@@ -1,34 +1,45 @@
-import { CommonModule } from '@angular/common';
 import { Component, inject, OnInit } from '@angular/core';
 import { NzCardModule } from 'ng-zorro-antd/card';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { NzSpinModule } from 'ng-zorro-antd/spin';
+import { PublisherStatistics } from '../../models/publishers-stats.models';
 import { PublishersStatsService } from '../../services/publishers-stats.service';
+
+interface StatCard {
+  key: keyof PublisherStatistics;
+  label: string;
+  value: number;
+  icon: string;
+  bgColor: string;
+  iconColor: string;
+}
 
 @Component({
   selector: 'app-publishers-stats-cards',
   standalone: true,
-  imports: [CommonModule, NzGridModule, NzCardModule, NzSpinModule],
+  imports: [NzGridModule, NzCardModule, NzSpinModule],
   template: `
     <div nz-row [nzGutter]="16" class="stats-container">
-      <div nz-col [nzSpan]="8" *ngFor="let card of cards">
-        <nz-card class="stat-card" [nzLoading]="loading">
-          <div class="stat-content">
-            <div
-              class="stat-icon"
-              [style.backgroundColor]="card.bgColor"
-              [style.color]="card.iconColor"
-            >
-              <i [class]="card.icon"></i>
-            </div>
+      @for (card of cards; track card.key) {
+        <div nz-col [nzSpan]="8">
+          <nz-card class="stat-card" [nzLoading]="loading">
+            <div class="stat-content">
+              <div
+                class="stat-icon"
+                [style.backgroundColor]="card.bgColor"
+                [style.color]="card.iconColor"
+              >
+                <i [class]="card.icon"></i>
+              </div>
 
-            <div class="stat-info">
-              <div class="stat-value">{{ card.value }}</div>
-              <div class="stat-label">{{ card.label }}</div>
+              <div class="stat-info">
+                <div class="stat-value">{{ card.value }}</div>
+                <div class="stat-label">{{ card.label }}</div>
+              </div>
             </div>
-          </div>
-        </nz-card>
-      </div>
+          </nz-card>
+        </div>
+      }
     </div>
   `,
   styles: [
@@ -76,7 +87,7 @@ export class PublishersStatsCardsComponent implements OnInit {
   private statsService = inject(PublishersStatsService);
   loading = true;
 
-  cards: any[] = [
+  cards: StatCard[] = [
     {
       key: 'total_publishers',
       label: 'إجمالي الناشرين',
@@ -107,7 +118,7 @@ export class PublishersStatsCardsComponent implements OnInit {
     this.statsService.getStatistics().subscribe({
       next: (stats) => {
         this.cards.forEach((card) => {
-          card.value = (stats as any)[card.key] || 0;
+          card.value = stats[card.key] || 0;
         });
         this.loading = false;
       },


### PR DESCRIPTION
## ماذا يفعل هذا الـ PR؟

تحسين أمان الأنواع في مكونات الناشرين والانتقال من directives القديمة للـ control flow الأصلي.

## التغييرات

### publishers-stats-cards.component.ts
- إنشاء واجهة `StatCard` مع `key: keyof PublisherStatistics` للوصول الآمن للبيانات
- استبدال `cards: any[]` بـ `cards: StatCard[]`
- إزالة `(stats as any)[card.key]` واستبداله بـ `stats[card.key]` الآمن
- تحويل `*ngFor` إلى `@for` مع `track card.key`
- إزالة `CommonModule`

### publisher-add.component.ts
- تحويل `*ngIf` إلى `@if`
- إزالة `CommonModule`

## لماذا؟

- `any[]` يلغي فائدة TypeScript في اكتشاف الأخطاء وقت التطوير
- `(stats as any)` كان غير ضروري لأن واجهة `PublisherStatistics` موجودة بالفعل مع المفاتيح الصحيحة
- Angular built-in control flow أفضل أداءً من structural directives

## الاختبار

- البناء يعمل بنجاح بدون أخطاء
- عدد أخطاء ESLint انخفض من 31 إلى 26 (5 أخطاء أقل)
- لم تتأثر وظائف المكونات

## المهمة المرتبطة

Closes #106