### PR TITLE
refactor(publishers): migrate remaining *ngIf/*ngFor to built-in control flow

### DIFF
--- a/src/app/features/quranic-cms/publishers/components/publisher-filters/publisher-filters.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publisher-filters/publisher-filters.component.ts
@@ -94,7 +94,7 @@ export class PublisherFiltersComponent implements OnInit, OnDestroy {
   @Output() searchChanged = new EventEmitter<string>();
   @Output() filterChanged = new EventEmitter<boolean | null>();
 
-  searchTerm: string = '';
+  searchTerm = '';
   activeFilter: boolean | null = null;
 
   private searchSubject = new Subject<string>();

--- a/src/app/features/quranic-cms/publishers/components/publisher-list/publisher-list.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publisher-list/publisher-list.component.ts
@@ -1,5 +1,4 @@
 import { ScrollingModule } from '@angular/cdk/scrolling';
-import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { NzEmptyModule } from 'ng-zorro-antd/empty';
 import { NzGridModule } from 'ng-zorro-antd/grid';
@@ -11,7 +10,6 @@ import { PublisherCardComponent } from '../publisher-card/publisher-card.compone
   selector: 'app-publisher-list',
   standalone: true,
   imports: [
-    CommonModule,
     NzGridModule,
     NzEmptyModule,
     NzSpinModule,
@@ -21,32 +19,39 @@ import { PublisherCardComponent } from '../publisher-card/publisher-card.compone
   template: `
     <div class="list-container" #scrollContainer>
       <div nz-row [nzGutter]="[16, 16]">
-        <div
-          nz-col
-          [nzXs]="24"
-          [nzSm]="12"
-          [nzMd]="8"
-          [nzLg]="8"
-          *ngFor="let publisher of publishers"
-        >
-          <app-publisher-card [publisher]="publisher"></app-publisher-card>
+        @for (publisher of publishers; track publisher.id) {
+          <div
+            nz-col
+            [nzXs]="24"
+            [nzSm]="12"
+            [nzMd]="8"
+            [nzLg]="8"
+          >
+            <app-publisher-card [publisher]="publisher"></app-publisher-card>
+          </div>
+        }
+      </div>
+
+      @if (loading) {
+        <div class="loading-spinner">
+          <nz-spin nzSimple nzSize="large"></nz-spin>
         </div>
-      </div>
+      }
 
-      <div *ngIf="loading" class="loading-spinner">
-        <nz-spin nzSimple nzSize="large"></nz-spin>
-      </div>
+      @if (!loading && publishers.length === 0) {
+        <div class="empty-state">
+          <nz-empty
+            nzNotFoundImage="simple"
+            nzNotFoundContent="عذراً، لا يوجد ناشرون حالياً"
+          ></nz-empty>
+        </div>
+      }
 
-      <div *ngIf="!loading && publishers.length === 0" class="empty-state">
-        <nz-empty
-          nzNotFoundImage="simple"
-          nzNotFoundContent="عذراً، لا يوجد ناشرون حالياً"
-        ></nz-empty>
-      </div>
-
-      <div *ngIf="!hasMore && publishers.length > 0" class="no-more">
-        <p>لا يوجد المزيد من الناشرين</p>
-      </div>
+      @if (!hasMore && publishers.length > 0) {
+        <div class="no-more">
+          <p>لا يوجد المزيد من الناشرين</p>
+        </div>
+      }
     </div>
   `,
   styles: [

--- a/src/app/features/quranic-cms/publishers/publishers.component.ts
+++ b/src/app/features/quranic-cms/publishers/publishers.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, HostListener, inject, OnInit } from '@angular/core';
 import { PublisherAddComponent } from './components/publisher-add/publisher-add.component';
 import { PublisherFiltersComponent } from './components/publisher-filters/publisher-filters.component';
@@ -12,7 +11,6 @@ import { PublishersService } from './services/publishers.service';
   selector: 'app-publishers',
   standalone: true,
   imports: [
-    CommonModule,
     PublishersBannerComponent,
     PublishersStatsCardsComponent,
     PublisherFiltersComponent,
@@ -25,11 +23,12 @@ import { PublishersService } from './services/publishers.service';
       <app-publishers-stats-cards></app-publishers-stats-cards>
 
       <div class="action-bar">
-        <app-publisher-filters
-          *ngIf="!isAdding"
-          (searchChanged)="onSearch($event)"
-          (filterChanged)="onFilterChange($event)"
-        ></app-publisher-filters>
+        @if (!isAdding) {
+          <app-publisher-filters
+            (searchChanged)="onSearch($event)"
+            (filterChanged)="onFilterChange($event)"
+          ></app-publisher-filters>
+        }
 
         <app-publisher-add
           [(isAdding)]="isAdding"
@@ -37,12 +36,13 @@ import { PublishersService } from './services/publishers.service';
         ></app-publisher-add>
       </div>
 
-      <app-publisher-list
-        *ngIf="!isAdding"
-        [publishers]="publishers"
-        [loading]="loading"
-        [hasMore]="hasMore"
-      ></app-publisher-list>
+      @if (!isAdding) {
+        <app-publisher-list
+          [publishers]="publishers"
+          [loading]="loading"
+          [hasMore]="hasMore"
+        ></app-publisher-list>
+      }
     </div>
   `,
   styles: [


### PR DESCRIPTION
## ماذا يفعل هذا الـ PR؟

استكمال ترحيل وحدة الناشرين من structural directives القديمة إلى Angular built-in control flow.

## التغييرات

### publisher-list.component.ts
- تحويل `*ngFor="let publisher of publishers"` إلى `@for (publisher of publishers; track publisher.id)`
- تحويل `*ngIf` إلى `@if` لحالات التحميل والفراغ والنهاية
- إزالة `CommonModule`

### publishers.component.ts
- تحويل `*ngIf="!isAdding"` إلى `@if (!isAdding)` للفلاتر والقائمة
- إزالة `CommonModule`

### publisher-filters.component.ts
- إزالة تعيين النوع المستنتج: `searchTerm: string = ''` → `searchTerm = ''`

## لماذا؟

- Angular built-in control flow (`@if`, `@for`) أفضل أداءً ولا تحتاج CommonModule
- `@for` مع `track` يحسّن أداء إعادة الرسم عند تغيير القائمة
- هذا يكمّل ترحيل وحدة الناشرين بالكامل

## الاختبار

- البناء يعمل بنجاح بدون أخطاء
- عدد أخطاء ESLint انخفض من 31 إلى 24 (7 أخطاء أقل على هذا الفرع)
- لم تتأثر وظائف المكونات

## المهمة المرتبطة

Closes #108