### PR TITLE
fix: resolve lint errors in recitations spec files

### DIFF
--- a/src/app/features/quranic-cms/components/recitations-stats-cards/recitations-stats-cards.component.spec.ts
+++ b/src/app/features/quranic-cms/components/recitations-stats-cards/recitations-stats-cards.component.spec.ts
@@ -5,7 +5,6 @@ import { RecitationsStatsService } from '../../services/recitations-stats.servic
 import { RecitationsStatsCardsComponent } from './recitations-stats-cards.component';
 
 describe('RecitationsStatsCardsComponent (Quranic CMS)', () => {
-  let component: RecitationsStatsCardsComponent;
   let fixture: ComponentFixture<RecitationsStatsCardsComponent>;
   let statsServiceSpy: jasmine.SpyObj<RecitationsStatsService>;
 
@@ -26,7 +25,6 @@ describe('RecitationsStatsCardsComponent (Quranic CMS)', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(RecitationsStatsCardsComponent);
-    component = fixture.componentInstance;
     fixture.detectChanges();
   });
 

--- a/src/app/features/quranic-cms/services/recitations-stats.service.spec.ts
+++ b/src/app/features/quranic-cms/services/recitations-stats.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { NzMessageService } from 'ng-zorro-antd/message';
-import { environment } from '../../../../environments/environment';
+import { RecitationsStats } from '../models/recitations-stats.model';
 import { RecitationsStatsService } from './recitations-stats.service';
 
 describe('RecitationsStatsService (Quranic CMS)', () => {
@@ -26,13 +26,11 @@ describe('RecitationsStatsService (Quranic CMS)', () => {
   });
 
   it('should return real stats when API succeeds', () => {
-    let resultStats: any;
+    let resultStats: RecitationsStats | undefined;
 
     service.getStats().subscribe((stats) => {
       resultStats = stats;
     });
-
-    const base = environment.API_BASE_URL;
 
     const req1 = httpMock.expectOne((req) => req.url.includes('/riwayas/'));
     const req2 = httpMock.expectOne((req) => req.url.includes('/reciters/'));
@@ -47,21 +45,19 @@ describe('RecitationsStatsService (Quranic CMS)', () => {
     req3.flush({ count: 20, results: [] });
 
     expect(resultStats).toBeDefined();
-    expect(resultStats.riwayas).toBe(10);
-    expect(resultStats.reciters).toBe(5);
-    expect(resultStats.recitations).toBe(20);
-    expect(resultStats.isMock).toBeFalsy();
+    expect(resultStats!.riwayas).toBe(10);
+    expect(resultStats!.reciters).toBe(5);
+    expect(resultStats!.recitations).toBe(20);
+    expect(resultStats!.isMock).toBeFalsy();
     expect(messageServiceSpy.error).not.toHaveBeenCalled();
   });
 
   it('should fall back to MOCK stats and show toaster on error', () => {
-    let resultStats: any;
+    let resultStats: RecitationsStats | undefined;
 
     service.getStats().subscribe((stats) => {
       resultStats = stats;
     });
-
-    const base = environment.API_BASE_URL;
 
     // We catch all 3 parallel requests
     const req1 = httpMock.expectOne((req) => req.url.includes('/riwayas/'));
@@ -76,8 +72,8 @@ describe('RecitationsStatsService (Quranic CMS)', () => {
     expect(req3.cancelled).toBeTrue();
 
     expect(resultStats).toBeDefined();
-    expect(resultStats.isMock).toBeTrue();
-    expect(resultStats.riwayas).toBeGreaterThan(0);
+    expect(resultStats!.isMock).toBeTrue();
+    expect(resultStats!.riwayas).toBeGreaterThan(0);
     expect(messageServiceSpy.error).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## ملخص التغييرات

إصلاح أخطاء ESLint في ملفات الاختبار الخاصة بوحدة التلاوات.

Closes #110

### التغييرات:

**`recitations-stats.service.spec.ts`:**
- استبدال نوع `any` بـ `RecitationsStats | undefined` للمتغير `resultStats`
- إزالة المتغيرات غير المستخدمة `base`
- إزالة استيراد `environment` غير المستخدم
- إضافة استيراد `RecitationsStats` من ملف النماذج

**`recitations-stats-cards.component.spec.ts`:**
- إزالة المتغير غير المستخدم `component`

### التحقق:
- ✅ `ng lint` يمر بنجاح على الملفات المعدلة
- ✅ `ng build` يعمل بدون أخطاء
- ✅ تقليل أخطاء ESLint الكلية من 31 إلى 26