### PR TITLE
fix: add cleanup for search timeout and accessibility in reciters page

### DIFF
--- a/src/app/features/quranic-cms/audio/reciters/reciters.page.html
+++ b/src/app/features/quranic-cms/audio/reciters/reciters.page.html
@@ -57,6 +57,7 @@
         class="reciters-toolbar__search-input"
         type="text"
         placeholder="ابحث بالاسم (عربي أو إنجليزي)..."
+        aria-label="البحث عن قارئ"
         (input)="onSearchInput($event)"
       />
     </div>

--- a/src/app/features/quranic-cms/audio/reciters/reciters.page.ts
+++ b/src/app/features/quranic-cms/audio/reciters/reciters.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, computed, inject, signal } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { NzButtonComponent } from 'ng-zorro-antd/button';
 import { NzFormModule } from 'ng-zorro-antd/form';
@@ -21,7 +21,7 @@ import { RecitersService } from '../services/reciters.service';
   templateUrl: './reciters.page.html',
   styleUrls: ['./reciters.page.less'],
 })
-export class RecitersPage implements OnInit {
+export class RecitersPage implements OnInit, OnDestroy {
   private readonly recitersService = inject(RecitersService);
   private readonly fb = inject(FormBuilder);
   private readonly messages = inject(NzMessageService);
@@ -64,6 +64,12 @@ export class RecitersPage implements OnInit {
 
     this.loadStats();
     this.loadReciters();
+  }
+
+  ngOnDestroy(): void {
+    if (this.searchTimeout) {
+      clearTimeout(this.searchTimeout);
+    }
   }
 
   setSubTab(tab: 'reciters' | 'recitations'): void {


### PR DESCRIPTION
## ملخص التغييرات

إصلاح تسريب ذاكرة وتحسين إمكانية الوصول في صفحة القرّاء.

Closes #112

### التغييرات:

**`reciters.page.ts`:**
- إضافة `OnDestroy` لمسح `searchTimeout` عند تدمير المكون
- يمنع تنفيذ callback الـ setTimeout على مكون مُدمَّر

**`reciters.page.html`:**
- إضافة `aria-label="البحث عن قارئ"` لحقل البحث لتحسين تجربة قارئات الشاشة

### التحقق:
- ✅ `ng lint` يمر بنجاح
- ✅ `ng build` يعمل بدون أخطاء