### PR TITLE
refactor(auth): remove commented-out old model interfaces

### DIFF
--- a/src/app/core/auth/models/auth.model.ts
+++ b/src/app/core/auth/models/auth.model.ts
@@ -2,39 +2,14 @@
  * Authentication models based on the Itqan CMS API schema
  */
 
-// export interface User { // OLD USER MODEL
-//   id: number;
-//   email: string;
-//   name: string;
-//   first_name: string;
-//   last_name: string;
-//   phone_number?: string;
-//   title?: string;
-//   avatar_url?: string;
-//   bio?: string;
-//   organization?: string;
-//   location?: string;
-//   website?: string;
-//   github_username?: string;
-//   email_verified: boolean;
-//   profile_completed: boolean;
-//   auth_provider: 'email' | 'google' | 'github';
-// }
-
 export interface User {
-  id: string; // TODO: Change to number
+  id: string;
   name: string;
   email: string;
   phone: string;
   is_active: boolean;
   is_profile_completed: boolean;
 }
-
-// export interface AuthResponse { // OLD AUTH RESPONSE MODEL
-//   access_token: string;
-//   refresh_token: string;
-//   user: User;
-// }
 
 export interface AuthResponse {
   access: string;
@@ -46,15 +21,6 @@ export interface LoginRequest {
   email: string;
   password: string;
 }
-
-// export interface RegisterRequest { // OLD REGISTER REQUEST MODEL
-//   email: string;
-//   password: string;
-//   first_name: string;
-//   last_name: string;
-//   phone_number?: string;
-//   title?: string;
-// }
 
 export interface RegisterRequest {
   email: string;
@@ -68,41 +34,16 @@ export interface RefreshTokenRequest {
   refresh: string;
 }
 
-// export interface RefreshTokenResponse { // OLD REFRESH TOKEN RESPONSE MODEL
-//   access_token: string;
-// }
-
 export interface RefreshTokenResponse {
   access: string;
   refresh: string;
 }
-
-// export interface UpdateProfileRequest { // OLD UPDATE PROFILE REQUEST MODEL
-//   name?: string;
-//   first_name?: string;
-//   last_name?: string;
-//   phone_number?: string;
-//   title?: string;
-//   bio?: string;
-//   organization?: string;
-//   location?: string;
-//   website?: string;
-//   github_username?: string;
-// }
 
 export interface UpdateProfileRequest {
   bio?: string;
   project_summary?: string;
   project_url?: string;
 }
-
-// export interface UpdateProfileResponse {
-//   message: string;
-//   profile: {
-//     id: number;
-//     profile_completed: boolean;
-//   };
-// }
 
 export interface UpdateProfileResponse {
   id: string;


### PR DESCRIPTION
## ملخص التغييرات

حذف الكود الميت (5 كتل من الواجهات القديمة المعلقة) من ملف `auth.model.ts`.

Closes #114

### التغييرات:

- حذف واجهة `User` القديمة المعلقة (OLD USER MODEL)
- حذف واجهة `AuthResponse` القديمة المعلقة
- حذف واجهة `RegisterRequest` القديمة المعلقة
- حذف واجهة `RefreshTokenResponse` القديمة المعلقة
- حذف واجهة `UpdateProfileRequest` القديمة المعلقة
- حذف واجهة `UpdateProfileResponse` القديمة المعلقة
- حذف تعليق TODO غير ضروري على `User.id`

**إجمالي:** حذف ~60 سطر من الكود الميت، التاريخ محفوظ في Git.

### التحقق:
- ✅ `ng lint` يمر بنجاح
- ✅ `ng build` يعمل بدون أخطاء
- ✅ لا يوجد تأثير على الوظائف (حذف تعليقات فقط)