### PR TITLE
fix: add error handling to QuranDataService and remove unused import

### DIFF
--- a/src/app/core/auth/pages/complete-profile/complete-profile.page.ts
+++ b/src/app/core/auth/pages/complete-profile/complete-profile.page.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -11,7 +10,7 @@ import { AuthService } from '../../services/auth.service';
 @Component({
   selector: 'app-complete-profile-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslateModule, NzButtonComponent],
+  imports: [ReactiveFormsModule, TranslateModule, NzButtonComponent],
   templateUrl: './complete-profile.page.html',
   styleUrls: ['./complete-profile.page.less'],
 })

--- a/src/app/features/quranic-cms/services/quran-data.service.ts
+++ b/src/app/features/quranic-cms/services/quran-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { BehaviorSubject, Observable, map, shareReplay, tap } from 'rxjs';
+import { BehaviorSubject, Observable, catchError, map, of, shareReplay, tap } from 'rxjs';
 import { SURAHS_METADATA, JUZ_PAGE_MAPPING, SurahMetadata } from '../models/quran-metadata';
 
 export interface AyahMarker {
@@ -85,6 +85,10 @@ export class QuranDataService {
       .get<QuranDataJson>(this.JSON_PATH)
       .pipe(
         tap((data: QuranDataJson) => this.dataSubject.next(data)),
+        catchError(() => {
+          this.dataSubject.next({ pages: {} });
+          return of(null);
+        }),
         shareReplay(1)
       )
       .subscribe();


### PR DESCRIPTION
## ملخص التغييرات

إصلاح خطأ صامت في خدمة بيانات القرآن وتنظيف استيراد غير ضروري.

Closes #116

### التغييرات:

**`quran-data.service.ts`:**
- إضافة `catchError` في دالة `loadData()` لمعالجة فشل تحميل ملف JSON
- عند الفشل، يتم تعيين كائن فارغ `{ pages: {} }` بدلاً من ترك القيمة `null`
- هذا يمنع الخطأ الصامت ويسمح للمكونات بعرض حالة "لا توجد بيانات" بشكل صحيح

**`complete-profile.page.ts`:**
- إزالة استيراد `CommonModule` غير الضروري (القالب يستخدم `@if` فقط)

### التحقق:
- ✅ `ng lint` يمر بنجاح
- ✅ `ng build` يعمل بدون أخطاء