### PR TITLE
fix(publishers): add error handling to prevent frozen loading state

### DIFF
--- a/src/app/features/quranic-cms/publishers/publishers.component.ts
+++ b/src/app/features/quranic-cms/publishers/publishers.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, HostListener, inject, OnInit } from '@angular/core';
+import { NzMessageService } from 'ng-zorro-antd/message';
 import { PublisherAddComponent } from './components/publisher-add/publisher-add.component';
 import { PublisherFiltersComponent } from './components/publisher-filters/publisher-filters.component';
 import { PublisherListComponent } from './components/publisher-list/publisher-list.component';
@@ -72,6 +73,7 @@ import { PublishersService } from './services/publishers.service';
 })
 export class PublishersComponent implements OnInit {
   private publishersService = inject(PublishersService);
+  private message = inject(NzMessageService);
 
   publishers: Publisher[] = [];
   page = 1;
@@ -97,10 +99,16 @@ export class PublishersComponent implements OnInit {
         search: this.searchTerm,
         is_active: this.activeFilter ?? undefined,
       })
-      .subscribe((data) => {
-        this.publishers = [...this.publishers, ...data];
-        this.hasMore = data.length === this.limit;
-        this.loading = false;
+      .subscribe({
+        next: (data) => {
+          this.publishers = [...this.publishers, ...data];
+          this.hasMore = data.length === this.limit;
+          this.loading = false;
+        },
+        error: () => {
+          this.loading = false;
+          this.message.error('تعذر تحميل قائمة الناشرين');
+        },
       });
   }
 


### PR DESCRIPTION
## ملخص التغييرات

إضافة معالجة الأخطاء في دالة `loadPublishers()` لمنع تجمد حالة التحميل.

Closes #119

### التغييرات:

**`publishers.component.ts`:**
- تحويل `.subscribe(callback)` إلى `.subscribe({ next, error })` مع معالج أخطاء
- إعادة تعيين `loading = false` عند فشل الطلب
- عرض رسالة خطأ للمستخدم عبر `NzMessageService`
- إضافة حقن `NzMessageService`

### المشكلة:
بدون error handler، إذا فشل طلب API:
1. `loading` يبقى `true` للأبد
2. المستخدم يرى spinner دائم
3. التمرير اللانهائي يتوقف

### التحقق:
- ✅ `ng build` يعمل بدون أخطاء
- ✅ أخطاء lint الحالية هي أخطاء موجودة مسبقاً (تم إصلاحها في PR #109)