### PR TITLE
fix: remove duplicate quranic-cms route breaking publisherHostGuard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -18,10 +18,23 @@ export const routes: Routes = [
     path: 'quranic-cms',
     loadComponent: () =>
       import('./features/quranic-cms/quranic-cms.page').then((m) => m.QuranicCmsPage),
-    loadChildren: () =>
-      import('./features/quranic-cms/quranic-cms.routes').then((m) => m.quranicCmsRoutes),
-    data: { hideHeader: true, fullWidth: true },
     canActivate: [authGuard],
+    data: { hideHeader: true, fullWidth: true },
+    children: [
+      {
+        path: 'publishers',
+        loadChildren: () =>
+          import('./features/quranic-cms/publishers/publishers.routes').then(
+            (m) => m.publishersRoutes
+          ),
+        canActivate: [publisherHostGuard],
+      },
+      {
+        path: '',
+        loadChildren: () =>
+          import('./features/quranic-cms/quranic-cms.routes').then((m) => m.quranicCmsRoutes),
+      },
+    ],
   },
   {
     path: 'gallery/asset/:id',
@@ -69,29 +82,6 @@ export const routes: Routes = [
       ),
     canActivate: [publisherHostGuard], // Restrict access for publisher hosts
   },
-  {
-    path: 'quranic-cms',
-    loadComponent: () =>
-      import('./features/quranic-cms/quranic-cms.page').then((m) => m.QuranicCmsPage),
-    canActivate: [authGuard],
-    data: { hideHeader: true, fullWidth: true },
-    children: [
-      {
-        path: '',
-        loadChildren: () =>
-          import('./features/quranic-cms/quranic-cms.routes').then((m) => m.quranicCmsRoutes),
-      },
-      {
-        path: 'publishers',
-        loadChildren: () =>
-          import('./features/quranic-cms/publishers/publishers.routes').then(
-            (m) => m.publishersRoutes
-          ),
-        canActivate: [publisherHostGuard],
-      },
-    ],
-  },
-
   {
     path: 'license/:id',
     loadComponent: () =>


### PR DESCRIPTION
## ملخص التغييرات

يغلق #118

### المشكلة
مسار `quranic-cms` كان معرف مرتين في `app.routes.ts`. بسبب نظام التوجيه في Angular اللي بيستخدم "أول تطابق يكسب"، التعريف الثاني (اللي فيه `publisherHostGuard` على مسار publishers الفرعي) كان مش بيتوصله أبداً.

### الحل
- حذف التعريف المكرر الأول للمسار
- ترتيب المسارات الفرعية بحيث مسار `publishers` مع الـ guard يكون قبل مسار الـ catch-all الفاضي (`path: ''`)
- ده بيضمن إن `publisherHostGuard` بيتنفذ فعلياً لما حد يزور `/quranic-cms/publishers`

### التأثير الأمني
- المستخدمين من نطاقات الناشرين كانوا يقدروا يوصلوا لمسار `/quranic-cms/publishers` من غير ما الـ guard يمنعهم
- دلوقتي الـ guard بيشتغل بشكل صحيح وبيحول المستخدمين لصفحة `/gallery`

## خطة الاختبار
- [ ] التأكد من إن `/quranic-cms/publishers` بيشتغل بشكل طبيعي من النطاق الرئيسي
- [ ] التأكد من إن `publisherHostGuard` بيمنع الوصول من نطاقات الناشرين
- [ ] التأكد من إن باقي مسارات `quranic-cms` (search, mushafs, audio) شغالة

🤖 Generated with [Claude Code](https://claude.com/claude-code)