### PR TITLE
fix: حذف حقل تأكيد كلمة المرور المكرر في التسجيل وتنظيف complete-profile

### DIFF
--- a/src/app/core/auth/pages/complete-profile/complete-profile.page.ts
+++ b/src/app/core/auth/pages/complete-profile/complete-profile.page.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -11,7 +10,7 @@ import { AuthService } from '../../services/auth.service';
 @Component({
   selector: 'app-complete-profile-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslateModule, NzButtonComponent],
+  imports: [ReactiveFormsModule, TranslateModule, NzButtonComponent],
   templateUrl: './complete-profile.page.html',
   styleUrls: ['./complete-profile.page.less'],
 })

--- a/src/app/core/auth/pages/register/register.page.html
+++ b/src/app/core/auth/pages/register/register.page.html
@@ -208,65 +208,6 @@
         </div>
 
         <div class="register__field">
-          <label for="confirmPassword" class="register__label">{{
-            'AUTH.REGISTER.CONFIRM_PASSWORD_LABEL' | translate
-          }}</label>
-          <div class="register__input-wrapper">
-            <input
-              id="confirmPassword"
-              name="confirmPassword"
-              [type]="confirmPasswordVisible() ? 'text' : 'password'"
-              autocomplete="new-password"
-              formControlName="confirmPassword"
-              [placeholder]="'FORMS.PLACEHOLDERS.CONFIRM_PASSWORD' | translate"
-              class="register__input"
-              [class.register__input--invalid]="
-                (registerForm.get('confirmPassword')?.invalid &&
-                  registerForm.get('confirmPassword')?.touched) ||
-                (registerForm.errors?.['passwordMismatch'] &&
-                  registerForm.get('confirmPassword')?.touched)
-              "
-              [attr.aria-invalid]="
-                (registerForm.get('confirmPassword')?.invalid &&
-                  registerForm.get('confirmPassword')?.touched) ||
-                (registerForm.errors?.['passwordMismatch'] &&
-                  registerForm.get('confirmPassword')?.touched)
-              "
-            />
-            <button
-              type="button"
-              class="register__password-toggle"
-              (click)="toggleConfirmPasswordVisibility()"
-              [attr.aria-label]="
-                (confirmPasswordVisible()
-                  ? 'AUTH.REGISTER.HIDE_PASSWORD'
-                  : 'AUTH.REGISTER.SHOW_PASSWORD'
-                ) | translate
-              "
-            >
-              <i class="bx" [ngClass]="confirmPasswordVisible() ? 'bx-eye-closed' : 'bx-eye'"></i>
-            </button>
-          </div>
-          @if (
-            registerForm.get('confirmPassword')?.hasError('required') &&
-            registerForm.get('confirmPassword')?.touched
-          ) {
-            <p class="register__error">
-              {{ 'AUTH.REGISTER.ERRORS.PASSWORD_REQUIRED' | translate }}
-            </p>
-          }
-          @if (
-            registerForm.hasError('passwordMismatch') &&
-            registerForm.get('confirmPassword')?.touched &&
-            !registerForm.get('confirmPassword')?.hasError('required')
-          ) {
-            <p class="register__error">
-              {{ 'AUTH.REGISTER.ERRORS.PASSWORD_MISMATCH' | translate }}
-            </p>
-          }
-        </div>
-
-        <div class="register__field">
           <label for="title" class="register__label">{{
             'AUTH.REGISTER.TITLE_LABEL' | translate
           }}</label>


### PR DESCRIPTION
## ملخص التغييرات

إصلاح خطأ مرئي في صفحة التسجيل وتنظيف كود في صفحة إكمال الملف الشخصي.

Closes #132

### التغييرات:

**`register.page.html`:**
- حذف حقل `confirmPassword` المكرر (كان يظهر مرتين للمستخدم بنفس الـ FormControl)
- تقليل حجم الصفحة بحوالي 2 كيلوبايت

**`complete-profile.page.ts`:**
- إزالة `CommonModule` غير المطلوب (القالب يستخدم `@if` ولا يحتاج `*ngIf`)

### الاختبار:
- البناء يعمل بنجاح ✅
- حجم `register-page` chunk انخفض من 17.76 KB إلى 15.89 KB