### PR TITLE
refactor: إزالة CommonModule غير الضروري من 5 مكونات standalone

### DIFF
--- a/src/app/features/content-standards/content-standards.page.ts
+++ b/src/app/features/content-standards/content-standards.page.ts
@@ -1,12 +1,11 @@
 import { Component } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { BreadcrumbComponent } from '../../shared/components/breadcrumb/breadcrumb.component';
-import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-content-standards-page',
   standalone: true,
-  imports: [CommonModule, TranslateModule, BreadcrumbComponent],
+  imports: [TranslateModule, BreadcrumbComponent],
   templateUrl: './content-standards.page.html',
   styleUrls: ['./content-standards.page.less'],
 })

--- a/src/app/features/license/pages/license-details/license-details.page.ts
+++ b/src/app/features/license/pages/license-details/license-details.page.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
@@ -8,7 +7,7 @@ import { BreadcrumbComponent } from '../../../../shared/components/breadcrumb/br
 @Component({
   selector: 'app-license-details-page',
   standalone: true,
-  imports: [CommonModule, RouterModule, TranslateModule, BreadcrumbComponent, NzButtonModule],
+  imports: [RouterModule, TranslateModule, BreadcrumbComponent, NzButtonModule],
   templateUrl: './license-details.page.html',
   styleUrls: ['./license-details.page.less'],
 })

--- a/src/app/shared/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/components/breadcrumb/breadcrumb.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router, RouterModule } from '@angular/router';
@@ -16,7 +15,7 @@ interface Breadcrumb {
 @Component({
   selector: 'app-breadcrumb',
   standalone: true,
-  imports: [CommonModule, RouterModule, TranslateModule, NzBreadCrumbModule, NzIconModule],
+  imports: [RouterModule, TranslateModule, NzBreadCrumbModule, NzIconModule],
   templateUrl: './breadcrumb.component.html',
   styleUrl: './breadcrumb.component.less',
 })

--- a/src/app/shared/components/empty-placeholder/empty-placeholder.component.ts
+++ b/src/app/shared/components/empty-placeholder/empty-placeholder.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { NzEmptyModule } from 'ng-zorro-antd/empty';
@@ -6,7 +5,7 @@ import { NzEmptyModule } from 'ng-zorro-antd/empty';
 @Component({
   selector: 'app-empty-placeholder',
   standalone: true,
-  imports: [CommonModule, NzEmptyModule],
+  imports: [NzEmptyModule],
   template: `
     <div class="placeholder-container">
       <nz-empty

--- a/src/app/shared/components/user-avatar/user-avatar.component.ts
+++ b/src/app/shared/components/user-avatar/user-avatar.component.ts
@@ -1,5 +1,4 @@
 import { Component, input } from '@angular/core';
-import { CommonModule } from '@angular/common';
 
 export interface UserAvatarData {
   avatar_url?: string;
@@ -10,7 +9,6 @@ export interface UserAvatarData {
 @Component({
   selector: 'app-user-avatar',
   standalone: true,
-  imports: [CommonModule],
   styleUrls: ['./user-avatar.component.less'],
   template: `
     @if (user()?.avatar_url) {


### PR DESCRIPTION
## الوصف

إزالة `CommonModule` غير المستخدم من 5 مكونات standalone.

Closes #134

## التغييرات

| الملف | السبب |
|---|---|
| `content-standards.page.ts` | لا يستخدم أي توجيهات من CommonModule |
| `license-details.page.ts` | لا يستخدم أي توجيهات من CommonModule |
| `breadcrumb.component.ts` | يستخدم `@if`/`@for` المدمج |
| `empty-placeholder.component.ts` | يستخدم فقط `NzEmptyModule` |
| `user-avatar.component.ts` | يستخدم `@if` المدمج |

## التحقق

- [x] البناء ينجح بدون أخطاء (`ng build`)
- [x] لا يوجد أي استخدام لـ `*ngIf`, `*ngFor`, `[ngClass]`, `[ngStyle]` في هذه المكونات
- [x] جميع المكونات تستخدم التحكم المدمج `@if`/`@for` أو لا تحتاج توجيهات أصلاً