### PR TITLE
refactor: إزالة NzIconModule غير المستخدم من 4 مكونات

### DIFF
--- a/src/app/features/quranic-cms/publishers/components/publishers-banner/publishers-banner.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publishers-banner/publishers-banner.component.ts
@@ -1,10 +1,9 @@
 import { Component } from '@angular/core';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'app-publishers-banner',
   standalone: true,
-  imports: [NzIconModule],
+  imports: [],
   template: `
     <div class="banner-container">
       <div class="banner-content">

--- a/src/app/shared/components/filters/filters.component.ts
+++ b/src/app/shared/components/filters/filters.component.ts
@@ -5,7 +5,6 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzCheckboxComponent, NzCheckboxGroupComponent } from 'ng-zorro-antd/checkbox';
 import { NzDrawerModule } from 'ng-zorro-antd/drawer';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzInputModule } from 'ng-zorro-antd/input';
 import { Subject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs';
 import { Categories } from '../../../core/enums/categories.enum';
@@ -19,7 +18,6 @@ import { ViewportService } from '../../../core/services/viewport.service';
   imports: [
     NzInputModule,
     NzButtonModule,
-    NzIconModule,
     NzDrawerModule,
     TranslatePipe,
     NgTemplateOutlet,

--- a/src/app/shared/components/license-tag/license-tag.component.ts
+++ b/src/app/shared/components/license-tag/license-tag.component.ts
@@ -2,7 +2,6 @@ import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { Component, inject, input, signal } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { NzDrawerModule } from 'ng-zorro-antd/drawer';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzPopoverModule } from 'ng-zorro-antd/popover';
 import { NzTagModule } from 'ng-zorro-antd/tag';
 import { Licenses, LicensesColors } from '../../../core/enums/licenses.enum';
@@ -11,7 +10,7 @@ import { ViewportService } from '../../../core/services/viewport.service';
 @Component({
   selector: 'app-license-tag',
   standalone: true,
-  imports: [NgClass, NgTemplateOutlet, NzTagModule, NzIconModule, NzPopoverModule, NzDrawerModule],
+  imports: [NgClass, NgTemplateOutlet, NzTagModule, NzPopoverModule, NzDrawerModule],
   templateUrl: './license-tag.component.html',
   styleUrls: ['./license-tag.component.less'],
 })

--- a/src/app/shared/components/mobile-menu/mobile-menu.component.ts
+++ b/src/app/shared/components/mobile-menu/mobile-menu.component.ts
@@ -3,7 +3,6 @@ import { Component, inject, input, output } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { NzDrawerModule, NzDrawerPlacement } from 'ng-zorro-antd/drawer';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 import { LangSwitchComponent } from '../lang-switch/lang-switch.component';
 import { NavigationLink } from '../navigation-menu/navigation-menu.component';
 import { UserActionsComponent } from '../user-actions/user-actions.component';
@@ -13,7 +12,6 @@ import { UserActionsComponent } from '../user-actions/user-actions.component';
   standalone: true,
   imports: [
     NzDrawerModule,
-    NzIconModule,
     RouterModule,
     LangSwitchComponent,
     UserActionsComponent,


### PR DESCRIPTION
## الوصف

إزالة `NzIconModule` غير المستخدم من 4 مكونات تستخدم أيقونات Boxicons بدلاً من Ng-Zorro icons.

Closes #142

## التغييرات

| الملف | السبب |
|---|---|
| `publishers-banner.component.ts` | يستخدم `<i class="bx bx-newspaper">` وليس `nz-icon` |
| `filters.component.ts` | يستخدم `<i class="bx bx-filter">` و `<i class="bx bx-search">` |
| `license-tag.component.ts` | يستخدم `<i class="bx bx-*">` |
| `mobile-menu.component.ts` | يستخدم `<i class="bx bx-*">` |

## التحقق

- [x] البناء ينجح بدون أخطاء (`ng build`)
- [x] تم التحقق من أن كل template لا يستخدم `nz-icon` أو `nzIcon`
- [x] جميع الأيقونات المستخدمة هي Boxicons (`class="bx"`)