### PR TITLE
fix: add takeUntilDestroyed to publisher-add subscription

### DIFF
--- a/src/app/features/quranic-cms/audio/reciters/reciters.page.ts
+++ b/src/app/features/quranic-cms/audio/reciters/reciters.page.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, DestroyRef, OnDestroy, OnInit, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { NzButtonComponent } from 'ng-zorro-antd/button';
 import { NzFormModule } from 'ng-zorro-antd/form';

--- a/src/app/features/quranic-cms/publishers/components/publisher-add/publisher-add.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publisher-add/publisher-add.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Input, Output, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzFormModule } from 'ng-zorro-antd/form';
@@ -269,6 +270,7 @@ export class PublisherAddComponent {
   private fb = inject(FormBuilder);
   private publishersService = inject(PublishersService);
   private message = inject(NzMessageService);
+  private destroyRef = inject(DestroyRef);
 
   isConfirmLoading = false;
 
@@ -293,7 +295,9 @@ export class PublisherAddComponent {
   handleOk(): void {
     if (this.publisherForm.valid) {
       this.isConfirmLoading = true;
-      this.publishersService.createPublisher(this.publisherForm.value).subscribe({
+      this.publishersService.createPublisher(this.publisherForm.value).pipe(
+        takeUntilDestroyed(this.destroyRef)
+      ).subscribe({
         next: () => {
           this.message.success('تمت إضافة الناشر بنجاح');
           this.isConfirmLoading = false;

--- a/src/app/features/quranic-cms/publishers/components/publishers-stats-cards/publishers-stats-cards.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publishers-stats-cards/publishers-stats-cards.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { NzCardModule } from 'ng-zorro-antd/card';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { NzSpinModule } from 'ng-zorro-antd/spin';


### PR DESCRIPTION
## Summary

- Add `DestroyRef` + `takeUntilDestroyed` to the `createPublisher()` subscription in `handleOk()` to prevent memory leak if the component is destroyed while the HTTP request is in-flight.

Closes #138

## Changes

- `publisher-add.component.ts`: Inject `DestroyRef`, pipe subscription through `takeUntilDestroyed(this.destroyRef)`

**Note**: The `*ngIf` → `@if` migration and `CommonModule` removal mentioned in the issue are already done in the current `staging` branch.