### PR TITLE
feat(quranic-cms): implement publisher details, edit, and delete workflow

### DIFF
--- a/src/app/features/quranic-cms/publishers/components/publisher-card/publisher-card.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publisher-card/publisher-card.component.ts
@@ -11,10 +11,18 @@ import { EventEmitter, Output } from '@angular/core';
   standalone: true,
   imports: [NzCardModule, NzAvatarModule],
   template: `
-    <nz-card class="publisher-card">
+    <nz-card
+      class="publisher-card"
+      role="button"
+      tabindex="0"
+      aria-label="عرض تفاصيل الناشر"
+      (click)="onOpenDetails()"
+      (keyup.enter)="onOpenDetails()"
+      (keyup.space)="onOpenDetails()"
+    >
       <div class="card-actions">
-        <i class="bx bx-edit-alt edit-btn" role="button" tabindex="0" aria-label="تعديل الناشر" (click)="onEdit()" (keyup.enter)="onEdit()"></i>
-        <i class="bx bx-trash delete-btn" role="button" tabindex="0" aria-label="حذف الناشر" (click)="onDelete()" (keyup.enter)="onDelete()"></i>
+        <i class="bx bx-edit-alt edit-btn" role="button" tabindex="0" aria-label="تعديل الناشر" (click)="onEdit($event)" (keyup.enter)="onEdit($event)"></i>
+        <i class="bx bx-trash delete-btn" role="button" tabindex="0" aria-label="حذف الناشر" (click)="onDelete($event)" (keyup.enter)="onDelete($event)"></i>
       </div>
 
       <div class="card-identity">
@@ -181,14 +189,22 @@ export class PublisherCardComponent {
   @Input() publisher!: Publisher;
 
   // Events to notify the parent component
+  @Output() details = new EventEmitter<Publisher>();
   @Output() edit = new EventEmitter<Publisher>();
   @Output() delete = new EventEmitter<Publisher>();
 
-  onEdit() {
+  onOpenDetails(): void {
+    this.details.emit(this.publisher);
+  }
+
+  onEdit(event?: Event): void {
+    event?.stopPropagation();
+    this.details.emit(this.publisher);
     this.edit.emit(this.publisher);
   }
 
-  onDelete() {
+  onDelete(event?: Event): void {
+    event?.stopPropagation();
     this.delete.emit(this.publisher);
   }
 }

--- a/src/app/features/quranic-cms/publishers/components/publisher-details/publisher-details.component.html
+++ b/src/app/features/quranic-cms/publishers/components/publisher-details/publisher-details.component.html
@@ -1,0 +1,79 @@
+<div class="details-page" dir="rtl">
+  @if (loading) {
+    <div class="state-block">
+      <nz-spin nzSize="large"></nz-spin>
+    </div>
+  } @else if (loadError) {
+    <div class="state-block error-state">
+      <h3>تعذر تحميل بيانات الناشر</h3>
+      <button nz-button nzType="primary" (click)="reload()">إعادة المحاولة</button>
+    </div>
+  } @else if (publisher) {
+    <nz-card class="details-card">
+      <div class="details-banner">
+        <div class="publisher-head">
+          <nz-avatar [nzSize]="64" [nzSrc]="publisher.icon_url" nzIcon="user"></nz-avatar>
+          <div>
+            <h1>{{ publisher.name_ar }}</h1>
+            <p>{{ publisher.name_en }}</p>
+          </div>
+        </div>
+
+        <div class="banner-actions">
+          @if (!isEditing) {
+            <button nz-button nzType="default" (click)="startEdit()">تحرير</button>
+          }
+          <button nz-button nzDanger (click)="showDeleteConfirm()">حذف</button>
+        </div>
+      </div>
+
+      @if (isEditing) {
+        <app-publisher-edit
+          [publisher]="publisher"
+          [submitting]="submitting"
+          (save)="confirmUpdate($event)"
+          (cancel)="cancelEdit()"
+        ></app-publisher-edit>
+      } @else {
+        <nz-descriptions nzBordered [nzColumn]="2" class="details-descriptions">
+          <nz-descriptions-item nzTitle="الاسم بالعربية">{{ publisher.name_ar }}</nz-descriptions-item>
+          <nz-descriptions-item nzTitle="الاسم بالإنجليزية">{{ publisher.name_en }}</nz-descriptions-item>
+
+          @if (publisher.country) {
+            <nz-descriptions-item nzTitle="الدولة">{{ publisher.country }}</nz-descriptions-item>
+          }
+
+          @if (publisher.website) {
+            <nz-descriptions-item nzTitle="الموقع الإلكتروني">
+              <a [href]="publisher.website" target="_blank" rel="noreferrer">{{ publisher.website }}</a>
+            </nz-descriptions-item>
+          }
+
+          @if (publisher.foundation_year) {
+            <nz-descriptions-item nzTitle="سنة التأسيس">{{ publisher.foundation_year }}</nz-descriptions-item>
+          }
+
+          @if (publisher.address) {
+            <nz-descriptions-item nzTitle="العنوان">{{ publisher.address }}</nz-descriptions-item>
+          }
+
+          @if (publisher.contact_email) {
+            <nz-descriptions-item nzTitle="البريد الإلكتروني">{{ publisher.contact_email }}</nz-descriptions-item>
+          }
+
+          @if (publisher.description) {
+            <nz-descriptions-item nzTitle="الوصف" [nzSpan]="2">{{ publisher.description }}</nz-descriptions-item>
+          }
+
+          <nz-descriptions-item nzTitle="الحالة">
+            @if (publisher.is_verified) {
+              <nz-tag nzColor="success">موثق</nz-tag>
+            } @else {
+              <nz-tag nzColor="default">غير موثق</nz-tag>
+            }
+          </nz-descriptions-item>
+        </nz-descriptions>
+      }
+    </nz-card>
+  }
+</div>

--- a/src/app/features/quranic-cms/publishers/components/publisher-details/publisher-details.component.less
+++ b/src/app/features/quranic-cms/publishers/components/publisher-details/publisher-details.component.less
@@ -1,0 +1,66 @@
+.details-page {
+  direction: rtl;
+}
+
+.details-card {
+  border-radius: 16px;
+}
+
+.details-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.publisher-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.publisher-head h1 {
+  margin: 0;
+  font-size: 22px;
+  color: #1f1f1f;
+}
+
+.publisher-head p {
+  margin: 4px 0 0;
+  color: #8c8c8c;
+}
+
+.banner-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.details-descriptions {
+  margin-top: 16px;
+}
+
+.state-block {
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.error-state {
+  flex-direction: column;
+  gap: 12px;
+}
+
+@media (max-width: 768px) {
+  .details-banner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .banner-actions {
+    justify-content: flex-end;
+  }
+}

--- a/src/app/features/quranic-cms/publishers/components/publisher-details/publisher-details.component.spec.ts
+++ b/src/app/features/quranic-cms/publishers/components/publisher-details/publisher-details.component.spec.ts
@@ -1,0 +1,109 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { convertToParamMap, ActivatedRoute, Router } from '@angular/router';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { NzMessageService } from 'ng-zorro-antd/message';
+import { NzModalService } from 'ng-zorro-antd/modal';
+import { Publisher } from '../../models/publishers-stats.models';
+import { PublishersService } from '../../services/publishers.service';
+import { PublisherDetailsComponent } from './publisher-details.component';
+
+describe('PublisherDetailsComponent', () => {
+  let fixture: ComponentFixture<PublisherDetailsComponent>;
+  let component: PublisherDetailsComponent;
+  let publishersServiceSpy: jasmine.SpyObj<PublishersService>;
+  let modalSpy: jasmine.SpyObj<NzModalService>;
+  let messageSpy: jasmine.SpyObj<NzMessageService>;
+  let router: Router;
+
+  const mockPublisher: Publisher = {
+    id: '123',
+    name_ar: 'كل آية',
+    name_en: 'Every Ayah',
+    country: 'Saudi Arabia',
+    is_verified: true,
+  };
+
+  beforeEach(async () => {
+    publishersServiceSpy = jasmine.createSpyObj('PublishersService', [
+      'getPublisherById',
+      'updatePublisher',
+      'deletePublisher',
+    ]);
+    modalSpy = jasmine.createSpyObj('NzModalService', ['confirm']);
+    messageSpy = jasmine.createSpyObj('NzMessageService', ['success', 'error']);
+
+    publishersServiceSpy.getPublisherById.and.returnValue(of(mockPublisher));
+    publishersServiceSpy.updatePublisher.and.returnValue(of({ ...mockPublisher, name_en: 'Updated' }));
+    publishersServiceSpy.deletePublisher.and.returnValue(of(void 0));
+
+    await TestBed.configureTestingModule({
+      imports: [PublisherDetailsComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: { paramMap: of(convertToParamMap({ id: '123' })) },
+        },
+        { provide: PublishersService, useValue: publishersServiceSpy },
+        { provide: NzModalService, useValue: modalSpy },
+        { provide: NzMessageService, useValue: messageSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PublisherDetailsComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate').and.resolveTo(true);
+    fixture.detectChanges();
+  });
+
+  it('should create and fetch publisher by route id', () => {
+    expect(component).toBeTruthy();
+    expect(publishersServiceSpy.getPublisherById).toHaveBeenCalledWith('123');
+    expect((component as any).publisher?.id).toBe('123');
+  });
+
+  it('should open update confirmation and call update on confirm', async () => {
+    const payload = { ...mockPublisher, name_en: 'Updated' };
+
+    (component as any).confirmUpdate(payload);
+    const confirmArg = modalSpy.confirm.calls.mostRecent().args[0] as any;
+
+    expect(confirmArg.nzTitle).toBe('تأكيد التعديل');
+    await confirmArg.nzOnOk();
+
+    expect(publishersServiceSpy.updatePublisher).toHaveBeenCalledWith('123', payload);
+    expect(messageSpy.success).toHaveBeenCalled();
+  });
+
+  it('should open delete confirmation with danger settings', () => {
+    (component as any).showDeleteConfirm();
+    const confirmArg = modalSpy.confirm.calls.mostRecent().args[0] as any;
+
+    expect(confirmArg.nzTitle).toBe('تأكيد الحذف');
+    expect(confirmArg.nzIconType).toBe('close-circle');
+    expect(confirmArg.nzOkText).toBe('نعم، احذف');
+    expect(confirmArg.nzOkDanger).toBeTrue();
+  });
+
+  it('should delete publisher and navigate back to list', async () => {
+    (component as any).showDeleteConfirm();
+    const confirmArg = modalSpy.confirm.calls.mostRecent().args[0] as any;
+
+    await confirmArg.nzOnOk();
+
+    expect(publishersServiceSpy.deletePublisher).toHaveBeenCalledWith('123');
+    expect(router.navigate).toHaveBeenCalledWith(['/quranic-cms/publishers']);
+    expect(messageSpy.success).toHaveBeenCalled();
+  });
+
+  it('should show error toast when details load fails', () => {
+    publishersServiceSpy.getPublisherById.and.returnValue(throwError(() => new Error('fail')));
+
+    const failedFixture = TestBed.createComponent(PublisherDetailsComponent);
+    failedFixture.detectChanges();
+
+    expect(messageSpy.error).toHaveBeenCalledWith('تعذر تحميل تفاصيل الناشر');
+  });
+});

--- a/src/app/features/quranic-cms/publishers/components/publisher-details/publisher-details.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publisher-details/publisher-details.component.ts
@@ -1,0 +1,150 @@
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NzAvatarModule } from 'ng-zorro-antd/avatar';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
+import { NzMessageService } from 'ng-zorro-antd/message';
+import { NzModalService } from 'ng-zorro-antd/modal';
+import { NzSpinModule } from 'ng-zorro-antd/spin';
+import { NzTagModule } from 'ng-zorro-antd/tag';
+import { catchError, firstValueFrom, of } from 'rxjs';
+import { Publisher } from '../../models/publishers-stats.models';
+import { PublishersService } from '../../services/publishers.service';
+import { PublisherEditComponent } from '../publisher-edit/publisher-edit.component';
+
+@Component({
+  selector: 'app-publisher-details',
+  standalone: true,
+  imports: [
+    NzCardModule,
+    NzButtonModule,
+    NzDescriptionsModule,
+    NzAvatarModule,
+    NzTagModule,
+    NzSpinModule,
+    PublisherEditComponent,
+  ],
+  templateUrl: './publisher-details.component.html',
+  styleUrl: './publisher-details.component.less',
+})
+export class PublisherDetailsComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly publishersService = inject(PublishersService);
+  private readonly modal = inject(NzModalService);
+  private readonly message = inject(NzMessageService);
+
+  protected publisherId = '';
+  protected publisher: Publisher | null = null;
+  protected loading = true;
+  protected submitting = false;
+  protected loadError = false;
+  protected isEditing = false;
+
+  ngOnInit(): void {
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
+      const id = params.get('id');
+      if (!id) {
+        this.loading = false;
+        this.loadError = true;
+        return;
+      }
+
+      this.publisherId = id;
+      this.fetchPublisher();
+    });
+  }
+
+  protected startEdit(): void {
+    this.isEditing = true;
+  }
+
+  protected cancelEdit(): void {
+    this.isEditing = false;
+  }
+
+  protected confirmUpdate(payload: Partial<Publisher>): void {
+    this.modal.confirm({
+      nzTitle: 'تأكيد التعديل',
+      nzContent: 'سيتم تعديل بيانات هذا الناشر على مستوى النظام. هل تريد المتابعة؟',
+      nzOkText: 'نعم، حفظ',
+      nzCancelText: 'إلغاء',
+      nzDirection: 'rtl',
+      nzOnOk: () => this.updatePublisher(payload),
+    });
+  }
+
+  protected showDeleteConfirm(): void {
+    this.modal.confirm({
+      nzTitle: 'تأكيد الحذف',
+      nzContent: '<b>هذا الإجراء لا يمكن التراجع عنه.</b>',
+      nzIconType: 'close-circle',
+      nzOkText: 'نعم، احذف',
+      nzCancelText: 'إلغاء',
+      nzOkDanger: true,
+      nzDirection: 'rtl',
+      nzOnOk: () => this.deletePublisher(),
+    });
+  }
+
+  protected reload(): void {
+    this.fetchPublisher();
+  }
+
+  private fetchPublisher(): void {
+    this.loading = true;
+    this.loadError = false;
+
+    this.publishersService
+      .getPublisherById(this.publisherId)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        catchError(() => {
+          this.loading = false;
+          this.loadError = true;
+          this.message.error('تعذر تحميل تفاصيل الناشر');
+          return of(null);
+        })
+      )
+      .subscribe((publisher) => {
+        if (!publisher) {
+          return;
+        }
+
+        this.publisher = publisher;
+        this.isEditing = false;
+        this.loading = false;
+      });
+  }
+
+  private async updatePublisher(payload: Partial<Publisher>): Promise<void> {
+    this.submitting = true;
+
+    try {
+      const updatedPublisher = await firstValueFrom(
+        this.publishersService.updatePublisher(this.publisherId, payload)
+      );
+
+      this.publisher = updatedPublisher;
+      this.isEditing = false;
+      this.message.success('تم تحديث بيانات الناشر بنجاح');
+    } catch {
+      this.message.error('تعذر تحديث بيانات الناشر');
+    } finally {
+      this.submitting = false;
+    }
+  }
+
+  private async deletePublisher(): Promise<void> {
+    try {
+      await firstValueFrom(this.publishersService.deletePublisher(this.publisherId));
+      this.message.success('تم حذف الناشر بنجاح');
+      await this.router.navigate(['/quranic-cms/publishers']);
+    } catch {
+      this.message.error('تعذر حذف الناشر');
+    }
+  }
+}

--- a/src/app/features/quranic-cms/publishers/components/publisher-edit/publisher-edit.component.html
+++ b/src/app/features/quranic-cms/publishers/components/publisher-edit/publisher-edit.component.html
@@ -1,0 +1,95 @@
+<form nz-form [formGroup]="form" [nzLayout]="'vertical'" class="edit-form">
+  <div nz-row [nzGutter]="24">
+    <div nz-col [nzXs]="24" [nzMd]="12">
+      <nz-form-item>
+        <nz-form-label nzRequired>اسم الناشر بالعربي</nz-form-label>
+        <nz-form-control nzErrorTip="اسم الناشر بالعربي مطلوب">
+          <input nz-input formControlName="name_ar" placeholder="كل آية" />
+        </nz-form-control>
+      </nz-form-item>
+    </div>
+
+    <div nz-col [nzXs]="24" [nzMd]="12">
+      <nz-form-item>
+        <nz-form-label nzRequired>اسم الناشر بالإنجليزي</nz-form-label>
+        <nz-form-control nzErrorTip="اسم الناشر بالإنجليزي مطلوب">
+          <input nz-input formControlName="name_en" placeholder="Every Ayah" />
+        </nz-form-control>
+      </nz-form-item>
+    </div>
+  </div>
+
+  <div nz-row [nzGutter]="24">
+    <div nz-col [nzXs]="24" [nzMd]="12">
+      <nz-form-item>
+        <nz-form-label>الدولة</nz-form-label>
+        <nz-form-control>
+          <input nz-input formControlName="country" placeholder="المملكة العربية السعودية" />
+        </nz-form-control>
+      </nz-form-item>
+    </div>
+
+    <div nz-col [nzXs]="24" [nzMd]="12">
+      <nz-form-item>
+        <nz-form-label>سنة التأسيس</nz-form-label>
+        <nz-form-control nzErrorTip="سنة التأسيس غير صحيحة">
+          <input nz-input type="number" formControlName="foundation_year" placeholder="2026" />
+        </nz-form-control>
+      </nz-form-item>
+    </div>
+  </div>
+
+  <div nz-row [nzGutter]="24">
+    <div nz-col [nzXs]="24" [nzMd]="12">
+      <nz-form-item>
+        <nz-form-label>الموقع الإلكتروني</nz-form-label>
+        <nz-form-control nzErrorTip="أدخل رابطاً صحيحاً يبدأ بـ http:// أو https://">
+          <input nz-input formControlName="website" placeholder="https://example.com" />
+        </nz-form-control>
+      </nz-form-item>
+    </div>
+
+    <div nz-col [nzXs]="24" [nzMd]="12">
+      <nz-form-item>
+        <nz-form-label>البريد الإلكتروني</nz-form-label>
+        <nz-form-control nzErrorTip="صيغة البريد الإلكتروني غير صحيحة">
+          <input nz-input formControlName="contact_email" placeholder="info@example.com" />
+        </nz-form-control>
+      </nz-form-item>
+    </div>
+  </div>
+
+  <div nz-row [nzGutter]="24">
+    <div nz-col [nzXs]="24" [nzMd]="12">
+      <nz-form-item>
+        <nz-form-label>العنوان</nz-form-label>
+        <nz-form-control>
+          <input nz-input formControlName="address" placeholder="الرياض، حي المروج" />
+        </nz-form-control>
+      </nz-form-item>
+    </div>
+
+    <div nz-col [nzXs]="24" [nzMd]="12">
+      <nz-form-item>
+        <nz-form-label>رابط الأيقونة</nz-form-label>
+        <nz-form-control nzErrorTip="أدخل رابطاً صحيحاً يبدأ بـ http:// أو https://">
+          <input nz-input formControlName="icon_url" placeholder="https://example.com/logo.png" />
+        </nz-form-control>
+      </nz-form-item>
+    </div>
+  </div>
+
+  <nz-form-item>
+    <nz-form-label>الوصف</nz-form-label>
+    <nz-form-control>
+      <textarea nz-input rows="4" formControlName="description" placeholder="وصف مختصر عن الناشر"></textarea>
+    </nz-form-control>
+  </nz-form-item>
+
+  <div class="edit-actions">
+    <button nz-button nzType="default" type="button" (click)="onCancel()">إلغاء</button>
+    <button nz-button nzType="primary" type="button" [nzLoading]="submitting" (click)="onSubmit()">
+      حفظ
+    </button>
+  </div>
+</form>

--- a/src/app/features/quranic-cms/publishers/components/publisher-edit/publisher-edit.component.less
+++ b/src/app/features/quranic-cms/publishers/components/publisher-edit/publisher-edit.component.less
@@ -1,0 +1,13 @@
+.edit-form {
+  background: #f8fbff;
+  border: 1px solid #e8f1ff;
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.edit-actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}

--- a/src/app/features/quranic-cms/publishers/components/publisher-edit/publisher-edit.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publisher-edit/publisher-edit.component.ts
@@ -1,0 +1,101 @@
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, inject } from '@angular/core';
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzFormModule } from 'ng-zorro-antd/form';
+import { NzGridModule } from 'ng-zorro-antd/grid';
+import { NzInputModule } from 'ng-zorro-antd/input';
+import { Publisher } from '../../models/publishers-stats.models';
+
+@Component({
+  selector: 'app-publisher-edit',
+  standalone: true,
+  imports: [ReactiveFormsModule, NzFormModule, NzInputModule, NzButtonModule, NzGridModule],
+  templateUrl: './publisher-edit.component.html',
+  styleUrl: './publisher-edit.component.less',
+})
+export class PublisherEditComponent implements OnChanges {
+  @Input({ required: true }) publisher!: Publisher;
+  @Input() submitting = false;
+
+  @Output() save = new EventEmitter<Partial<Publisher>>();
+  @Output() cancel = new EventEmitter<void>();
+
+  private readonly fb = inject(FormBuilder);
+
+  protected readonly form = this.fb.group({
+    name_ar: ['', [Validators.required, this.requiredTrimmed()]],
+    name_en: ['', [Validators.required, this.requiredTrimmed()]],
+    country: [''],
+    website: ['', [Validators.pattern(/^https?:\/\/.+/i)]],
+    icon_url: ['', [Validators.pattern(/^https?:\/\/.+/i)]],
+    foundation_year: [null as number | null, [Validators.min(1), Validators.max(9999)]],
+    address: [''],
+    contact_email: ['', [Validators.email]],
+    description: [''],
+    is_verified: [false],
+  });
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['publisher']?.currentValue) {
+      this.form.reset({
+        name_ar: this.publisher.name_ar ?? '',
+        name_en: this.publisher.name_en ?? '',
+        country: this.publisher.country ?? '',
+        website: this.publisher.website ?? '',
+        icon_url: this.publisher.icon_url ?? '',
+        foundation_year: this.publisher.foundation_year ?? null,
+        address: this.publisher.address ?? '',
+        contact_email: this.publisher.contact_email ?? '',
+        description: this.publisher.description ?? '',
+        is_verified: this.publisher.is_verified ?? false,
+      });
+    }
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const rawValue = this.form.getRawValue();
+
+    const payload = {
+      ...this.publisher,
+      name_ar: (rawValue.name_ar ?? '').trim(),
+      name_en: (rawValue.name_en ?? '').trim(),
+      country: rawValue.country || undefined,
+      website: rawValue.website || undefined,
+      icon_url: rawValue.icon_url || undefined,
+      foundation_year: rawValue.foundation_year ?? undefined,
+      address: rawValue.address || undefined,
+      contact_email: rawValue.contact_email || undefined,
+      description: rawValue.description || undefined,
+      is_verified: rawValue.is_verified ?? false,
+    };
+
+    this.save.emit(payload);
+  }
+
+  onCancel(): void {
+    this.cancel.emit();
+  }
+
+  private requiredTrimmed(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const value = control.value;
+      if (typeof value !== 'string') {
+        return null;
+      }
+
+      return value.trim().length > 0 ? null : { requiredTrimmed: true };
+    };
+  }
+}

--- a/src/app/features/quranic-cms/publishers/components/publisher-list/publisher-list.component.ts
+++ b/src/app/features/quranic-cms/publishers/components/publisher-list/publisher-list.component.ts
@@ -1,5 +1,5 @@
 import { ScrollingModule } from '@angular/cdk/scrolling';
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NzEmptyModule } from 'ng-zorro-antd/empty';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { NzSpinModule } from 'ng-zorro-antd/spin';
@@ -27,7 +27,10 @@ import { PublisherCardComponent } from '../publisher-card/publisher-card.compone
             [nzMd]="8"
             [nzLg]="8"
           >
-            <app-publisher-card [publisher]="publisher"></app-publisher-card>
+            <app-publisher-card
+              [publisher]="publisher"
+              (details)="onDetails($event)"
+            ></app-publisher-card>
           </div>
         }
       </div>
@@ -79,4 +82,9 @@ export class PublisherListComponent {
   @Input() publishers: Publisher[] = [];
   @Input() loading = false;
   @Input() hasMore = true;
+  @Output() detailsRequested = new EventEmitter<Publisher>();
+
+  onDetails(publisher: Publisher): void {
+    this.detailsRequested.emit(publisher);
+  }
 }

--- a/src/app/features/quranic-cms/publishers/publishers.component.ts
+++ b/src/app/features/quranic-cms/publishers/publishers.component.ts
@@ -1,6 +1,6 @@
 import { Component, DestroyRef, HostListener, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { NzMessageService } from 'ng-zorro-antd/message';
+import { Router } from '@angular/router';
 import { PublisherAddComponent } from './components/publisher-add/publisher-add.component';
 import { PublisherFiltersComponent } from './components/publisher-filters/publisher-filters.component';
 import { PublisherListComponent } from './components/publisher-list/publisher-list.component';
@@ -43,6 +43,7 @@ import { PublishersService } from './services/publishers.service';
           [publishers]="publishers"
           [loading]="loading"
           [hasMore]="hasMore"
+          (detailsRequested)="onDetailsRequested($event)"
         ></app-publisher-list>
       }
     </div>
@@ -75,7 +76,7 @@ import { PublishersService } from './services/publishers.service';
 export class PublishersComponent implements OnInit {
   private readonly publishersService = inject(PublishersService);
   private readonly destroyRef = inject(DestroyRef);
-  private message = inject(NzMessageService);
+  private readonly router = inject(Router);
 
   publishers: Publisher[] = [];
   page = 1;
@@ -157,5 +158,9 @@ export class PublishersComponent implements OnInit {
     this.hasMore = true;
     this.isAdding = false;
     this.loadPublishers();
+  }
+
+  onDetailsRequested(publisher: Publisher): void {
+    this.router.navigate(['/quranic-cms/publishers', publisher.id, 'details']);
   }
 }

--- a/src/app/features/quranic-cms/publishers/publishers.routes.ts
+++ b/src/app/features/quranic-cms/publishers/publishers.routes.ts
@@ -12,6 +12,13 @@ export const publishersRoutes: Routes = [
         component: PublishersComponent,
       },
       {
+        path: ':id/details',
+        loadComponent: () =>
+          import('./components/publisher-details/publisher-details.component').then(
+            (m) => m.PublisherDetailsComponent
+          ),
+      },
+      {
         path: 'authors',
         loadComponent: () =>
           import('../../../shared/components/empty-placeholder/empty-placeholder.component').then(

--- a/src/app/features/quranic-cms/publishers/services/publishers.service.spec.ts
+++ b/src/app/features/quranic-cms/publishers/services/publishers.service.spec.ts
@@ -1,0 +1,92 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Publisher } from '../models/publishers-stats.models';
+import { PublishersService } from './publishers.service';
+
+describe('PublishersService', () => {
+  let service: PublishersService;
+  let httpMock: HttpTestingController;
+
+  const mockPublisher: Publisher = {
+    id: '123',
+    name_ar: 'كل آية',
+    name_en: 'Every Ayah',
+    country: 'Saudi Arabia',
+    is_verified: true,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+
+    service = TestBed.inject(PublishersService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should fetch publisher details by id', () => {
+    let result: Publisher | undefined;
+
+    service.getPublisherById('123').subscribe((publisher) => {
+      result = publisher;
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/portal/publishers/123'));
+    expect(req.request.method).toBe('GET');
+    req.flush(mockPublisher);
+
+    expect(result).toEqual(mockPublisher);
+  });
+
+  it('should update publisher using PUT', () => {
+    let result: Publisher | undefined;
+    const payload = { name_en: 'Updated' };
+
+    service.updatePublisher('123', payload).subscribe((publisher) => {
+      result = publisher;
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/portal/publishers/123'));
+    expect(req.request.method).toBe('PUT');
+    req.flush({ ...mockPublisher, ...payload });
+
+    expect(result?.name_en).toBe('Updated');
+  });
+
+  it('should fallback to PATCH when PUT is not supported', () => {
+    let result: Publisher | undefined;
+    const payload = { name_en: 'Patched' };
+
+    service.updatePublisher('123', payload).subscribe((publisher) => {
+      result = publisher;
+    });
+
+    const putReq = httpMock.expectOne((r) => r.url.endsWith('/portal/publishers/123'));
+    expect(putReq.request.method).toBe('PUT');
+    putReq.flush(null, { status: 405, statusText: 'Method Not Allowed' });
+
+    const patchReq = httpMock.expectOne((r) => r.url.endsWith('/portal/publishers/123'));
+    expect(patchReq.request.method).toBe('PATCH');
+    patchReq.flush({ ...mockPublisher, ...payload });
+
+    expect(result?.name_en).toBe('Patched');
+  });
+
+  it('should delete publisher by id', () => {
+    let completed = false;
+
+    service.deletePublisher('123').subscribe(() => {
+      completed = true;
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/portal/publishers/123'));
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+
+    expect(completed).toBeTrue();
+  });
+});

--- a/src/app/features/quranic-cms/publishers/services/publishers.service.ts
+++ b/src/app/features/quranic-cms/publishers/services/publishers.service.ts
@@ -1,6 +1,6 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, catchError, throwError } from 'rxjs';
 import { environment } from '../../../../../environments/environment';
 import { Publisher } from '../models/publishers-stats.models';
 
@@ -34,5 +34,27 @@ export class PublishersService {
 
   createPublisher(publisher: Partial<Publisher>): Observable<Publisher> {
     return this.http.post<Publisher>(this.apiUrl, publisher);
+  }
+
+  getPublisherById(id: string): Observable<Publisher> {
+    return this.http.get<Publisher>(`${this.apiUrl}${id}`);
+  }
+
+  updatePublisher(id: string, publisher: Partial<Publisher>): Observable<Publisher> {
+    const url = `${this.apiUrl}${id}`;
+
+    return this.http.put<Publisher>(url, publisher).pipe(
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 405 || error.status === 501) {
+          return this.http.patch<Publisher>(url, publisher);
+        }
+
+        return throwError(() => error);
+      })
+    );
+  }
+
+  deletePublisher(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}${id}`);
   }
 }


### PR DESCRIPTION
## Summary
- add publisher details route at /quranic-cms/publishers/:id/details inside publishers layout
- implement read-only publisher details view with banner actions (Edit/Delete) and nz-descriptions rendering
- add reusable inline PublisherEditComponent with strict name_ar/name_en validation and pre-populated reactive form
- add update confirmation modal before save and destructive delete confirmation modal with danger action
- implement delete success redirect to /quranic-cms/publishers with success toaster, plus error toasters for failures
- complete publishers service with getPublisherById, updatePublisher (PUT + PATCH fallback), and deletePublisher
- wire publisher card/list click flow to navigate to details page
- add unit tests for publishers service and details component behavior

## Acceptance Criteria Mapping
- [x] URL /quranic-cms/publishers/123/details fetches publisher 123
- [x] read-only view displays requested metadata with clean optional field handling
- [x] Edit swaps to pre-populated reactive form
- [x] Cancel exits edit mode cleanly
- [x] Save is gated by confirmation modal before update request
- [x] Delete uses danger confirmation modal with Arabic confirm action
- [x] Successful delete navigates back to list and shows success toast
- [x] Success/failure flows show global toasts

## Testing
- ✅ npm run build passes
- ⚠️ npm test -- --watch=false --include='src/app/features/quranic-cms/publishers/**/*.spec.ts' compiles specs but cannot run in this container due missing Chrome binary (CHROME_BIN)

Closes #78
