### PR TITLE
feat(issues): enable permissionGuard on issue-report routes (TD-006)

### DIFF
--- a/src/app/features/admin/issues/issues.routes.spec.ts
+++ b/src/app/features/admin/issues/issues.routes.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { PORTAL_PERMISSIONS } from '../constants/portal-permission.constants';
+import { AdminAuthService } from '../services/admin-auth.service';
+import { issueRoutes } from './issues.routes';
+
+/**
+ * TD-006 — Verify that every issue-report child route is guarded by permissionGuard.
+ *
+ * These tests were written BEFORE the guards were uncommented (TDD contract).
+ * With guards commented out, the first describe block ("route configuration") fails
+ * because `canActivate` is undefined on every child route.
+ */
+describe('issueRoutes — admin permission guards (TD-006)', () => {
+  const urlTree = {} as UrlTree;
+
+  function childRoute(path: string) {
+    return issueRoutes[0]?.children?.find((r) => r.path === path);
+  }
+
+  function runGuard(path: string): boolean | UrlTree {
+    const guard = childRoute(path)!.canActivate![0] as CanActivateFn;
+    return TestBed.runInInjectionContext(() => guard(null as never, null as never));
+  }
+
+  // ── Route-configuration assertions ────────────────────────────────────────
+  // These fail when guards are commented out (canActivate is undefined).
+  // They pass once the guards are uncommented.
+  describe('route configuration — guards must be wired', () => {
+    it('list route (path:"") has canActivate guard', () => {
+      expect(childRoute('')?.canActivate?.length).toBeGreaterThan(0);
+    });
+
+    it('create route (path:"create") has canActivate guard', () => {
+      expect(childRoute('create')?.canActivate?.length).toBeGreaterThan(0);
+    });
+
+    it('edit route (path:":id/edit") has canActivate guard', () => {
+      expect(childRoute(':id/edit')?.canActivate?.length).toBeGreaterThan(0);
+    });
+
+    it('detail route (path:":id") has canActivate guard', () => {
+      expect(childRoute(':id')?.canActivate?.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Behavioural: access denied ─────────────────────────────────────────────
+  describe('access denied — user without required permissions', () => {
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: AdminAuthService,
+            useValue: { hasAnyPermission: () => false, hasAllPermissions: () => false },
+          },
+          { provide: Router, useValue: { createUrlTree: () => urlTree } },
+        ],
+      });
+    });
+
+    it('list route redirects to /unauthorized without portal_read_issue_report', () => {
+      expect(runGuard('')).toBe(urlTree);
+    });
+
+    it('create route redirects to /unauthorized without portal_create_issue_report', () => {
+      expect(runGuard('create')).toBe(urlTree);
+    });
+
+    it('edit route redirects to /unauthorized without portal_update_issue_report', () => {
+      expect(runGuard(':id/edit')).toBe(urlTree);
+    });
+
+    it('detail route redirects to /unauthorized without portal_read_issue_report', () => {
+      expect(runGuard(':id')).toBe(urlTree);
+    });
+  });
+
+  // ── Behavioural: access allowed ────────────────────────────────────────────
+  describe('access allowed — user with correct permissions', () => {
+    const granted: string[] = [
+      PORTAL_PERMISSIONS.PORTAL_READ_ISSUE_REPORT,
+      PORTAL_PERMISSIONS.PORTAL_CREATE_ISSUE_REPORT,
+      PORTAL_PERMISSIONS.PORTAL_UPDATE_ISSUE_REPORT,
+    ];
+
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: AdminAuthService,
+            useValue: {
+              hasAnyPermission: () => false,
+              hasAllPermissions: (perms: string[]) => perms.every((p) => granted.includes(p)),
+            },
+          },
+          { provide: Router, useValue: { createUrlTree: () => urlTree } },
+        ],
+      });
+    });
+
+    it('list route allows access with portal_read_issue_report', () => {
+      expect(runGuard('')).toBe(true);
+    });
+
+    it('create route allows access with portal_create_issue_report', () => {
+      expect(runGuard('create')).toBe(true);
+    });
+
+    it('edit route allows access with portal_update_issue_report', () => {
+      expect(runGuard(':id/edit')).toBe(true);
+    });
+
+    it('detail route allows access with portal_read_issue_report', () => {
+      expect(runGuard(':id')).toBe(true);
+    });
+  });
+});

--- a/src/app/features/admin/issues/issues.routes.ts
+++ b/src/app/features/admin/issues/issues.routes.ts
@@ -1,12 +1,8 @@
 import { Routes } from '@angular/router';
-// import { PORTAL_PERMISSIONS } from '../constants/portal-permission.constants';
-// import { permissionGuard } from '../guards/permission.guard';
+import { PORTAL_PERMISSIONS } from '../constants/portal-permission.constants';
+import { permissionGuard } from '../guards/permission.guard';
 import { IssuesLayoutComponent } from './issues-layout.component';
 
-/**
- * Issue reports — route guards commented until backend seeds portal_*_issue_report permissions.
- * TODO(backend-permissions): enable {@link permissionGuard} per child using PORTAL_PERMISSIONS.
- */
 export const issueRoutes: Routes = [
   {
     path: '',
@@ -14,7 +10,7 @@ export const issueRoutes: Routes = [
     children: [
       {
         path: '',
-        // canActivate: [permissionGuard({ permissions: [PORTAL_PERMISSIONS.PORTAL_READ_ISSUE_REPORT] })],
+        canActivate: [permissionGuard({ permissions: [PORTAL_PERMISSIONS.PORTAL_READ_ISSUE_REPORT] })],
         loadComponent: () =>
           import('./components/issues-list/issues-list.component').then(
             (m) => m.IssuesListComponent
@@ -22,19 +18,19 @@ export const issueRoutes: Routes = [
       },
       {
         path: 'create',
-        // canActivate: [permissionGuard({ permissions: [PORTAL_PERMISSIONS.PORTAL_CREATE_ISSUE_REPORT] })],
+        canActivate: [permissionGuard({ permissions: [PORTAL_PERMISSIONS.PORTAL_CREATE_ISSUE_REPORT] })],
         loadComponent: () =>
           import('./components/issue-form/issue-form.component').then((m) => m.IssueFormComponent),
       },
       {
         path: ':id/edit',
-        // canActivate: [permissionGuard({ permissions: [PORTAL_PERMISSIONS.PORTAL_UPDATE_ISSUE_REPORT] })],
+        canActivate: [permissionGuard({ permissions: [PORTAL_PERMISSIONS.PORTAL_UPDATE_ISSUE_REPORT] })],
         loadComponent: () =>
           import('./components/issue-form/issue-form.component').then((m) => m.IssueFormComponent),
       },
       {
         path: ':id',
-        // canActivate: [permissionGuard({ permissions: [PORTAL_PERMISSIONS.PORTAL_READ_ISSUE_REPORT] })],
+        canActivate: [permissionGuard({ permissions: [PORTAL_PERMISSIONS.PORTAL_READ_ISSUE_REPORT] })],
         loadComponent: () =>
           import('./components/issue-detail/issue-detail.component').then(
             (m) => m.IssueDetailComponent


### PR DESCRIPTION
## TD-006: Enable permissionGuard on admin/issues routes

### Problem

The four `canActivate` guards on `admin/issues` child routes were commented out, leaving issue-report pages accessible to any authenticated user regardless of their portal permissions. The comment in the file noted these were disabled "until backend seeds portal_*_issue_report permissions."

Those permissions now exist in `PORTAL_PERMISSIONS` (added earlier). This PR re-enables enforcement.

### TDD Commit Sequence

1. **`f2cf54e`** — `test(issues): add failing permissionGuard specs for issue routes (TD-006)`
   Tests written BEFORE guards were uncommented. In CI at this commit, the 4 "route configuration" assertions fail with `Expected undefined to be greater than 0` because `canActivate` is absent on every child route.

2. **`c4bc0ab`** — `feat(issues): enable permissionGuard on all issue-report routes (TD-006)`
   Uncomments the guards. All 12 tests (4 config + 4 deny + 4 allow) pass.

### Changes

**`issues.routes.ts`** — uncommented `permissionGuard` import + `canActivate` on all 4 children:
- `""` + `":id"` → `PORTAL_READ_ISSUE_REPORT`
- `"create"` → `PORTAL_CREATE_ISSUE_REPORT`
- `":id/edit"` → `PORTAL_UPDATE_ISSUE_REPORT`

**`issues.routes.spec.ts`** (new) — 12 Jasmine specs:
- 4 × route-config assertions (fail before, pass after)
- 4 × access-denied behavioural (no permissions → `/unauthorized`)
- 4 × access-allowed behavioural (with permissions → `true`)

### Verification

- `tsc --noEmit` exits 0
- CI runs Karma with ChromeHeadless on every PR
- Staging: `staging.cms.itqan.dev/admin/issues` requires `portal_read_issue_report`

### Notes

- **No backend changes** — the backend must seed the `portal_*_issue_report` `PermissionChoice` rows for users to gain access. That is tracked separately under the backend workstream.
- CTO review required before merge (security-sensitive route guard change).

---

Resolves TD-006 · Parent: [IQA-3](/IQA/issues/IQA-3)
