### PR TITLE
fix(ci): use Node 22 for release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
semantic-release@25 requires Node ^22.14.0 or >=24.10.0. The release job was using 20.x which caused: `node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.`