### PR TITLE
fix(ci): format package.json with prettier after semantic-release bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
       "eslint --fix --cache --concurrency=auto",
       "prettier --write"
     ],
-    "*.{json,html,css,less,md}": [
-      "prettier --write"
-    ]
+    "*.{json,html,css,less,md}": ["prettier --write"]
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
semantic-release rewrites package.json with multi-line array format; prettier expects single-line. Fixes format:check CI failure.