### PR TITLE
fix(sentry): recover chunk/i18n network failures and drop status-0 noise

### DIFF
--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -147,16 +147,17 @@ cms-frontend/
 
 ### Core Layer (`src/app/core/`)
 
-| Subdirectory     | Contents                                                                                                                       | Purpose                                                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
-| `auth/`          | 21 pages + 1 service + 3 guards + headless API module (20+ files)                                                              | Full django-allauth headless SPA integration               |
-| `auth/headless/` | `HeadlessAuthApiService` (~60 methods), `HeadlessAppTokenService`, types, hooks, WebAuthn utils, CSRF utils, provider redirect | allauth headless contract implementation                   |
-| `constants/`     | `BREAKPOINTS`, `NAV_LINKS`                                                                                                     | Responsive breakpoints + navigation link definitions       |
-| `enums/`         | `Categories` (tafsir/translation/recitation), `Licenses` (CC0-CC-BY-NC-ND + colors)                                            | Content categorization and licensing                       |
-| `guards/`        | `publisherHostGuard`                                                                                                           | Blocks publisher subdomain visitors from CMS routes        |
-| `interceptors/`  | 6 interceptors (credentials, CSRF response, app-session-token, headers/global, auth-error, error)                              | HTTP pipeline: session token, CSRF, error handling, Sentry |
-| `services/`      | `GoogleAnalyticsService`, `WebVitalsService`, `ViewportService`                                                                | Analytics, Core Web Vitals, responsive viewport detection  |
-| `utils/`         | `csrf.util.ts`                                                                                                                 | Django CSRF (same-origin cookies + cross-origin override)  |
+| Subdirectory     | Contents                                                                                                                       | Purpose                                                           |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `auth/`          | 21 pages + 1 service + 3 guards + headless API module (20+ files)                                                              | Full django-allauth headless SPA integration                      |
+| `auth/headless/` | `HeadlessAuthApiService` (~60 methods), `HeadlessAppTokenService`, types, hooks, WebAuthn utils, CSRF utils, provider redirect | allauth headless contract implementation                          |
+| `constants/`     | `BREAKPOINTS`, `NAV_LINKS`                                                                                                     | Responsive breakpoints + navigation link definitions              |
+| `enums/`         | `Categories` (tafsir/translation/recitation), `Licenses` (CC0-CC-BY-NC-ND + colors)                                            | Content categorization and licensing                              |
+| `guards/`        | `publisherHostGuard`                                                                                                           | Blocks publisher subdomain visitors from CMS routes               |
+| `interceptors/`  | 6 interceptors (credentials, CSRF response, app-session-token, headers/global, auth-error, error)                              | HTTP pipeline: session token, CSRF, error handling, Sentry        |
+| `sentry/`        | chunk-load recovery, `beforeSend` noise filter, app ErrorHandler wrapper                                                       | Benign network/chunk failures: one-time reload + drop from Sentry |
+| `services/`      | `GoogleAnalyticsService`, `WebVitalsService`, `ViewportService`                                                                | Analytics, Core Web Vitals, responsive viewport detection         |
+| `utils/`         | `csrf.util.ts`                                                                                                                 | Django CSRF (same-origin cookies + cross-origin override)         |
 
 ### Interceptor Pipeline (order matters)
 
@@ -169,6 +170,17 @@ Response: authErrorInterceptor -> errorInterceptor
 `409` + `unverified_email` on `/auth/app/v1/*`: no global error toast, no Sentry; pages redirect to
 `/account/verify-email?reason=unverified_email` (login/register/security settings) with copy on
 verify-email.
+
+HTTP `status === 0` (network abort / offline): suppressed from Sentry in `authErrorInterceptor`;
+user toast still via `error.interceptor` (`ERRORS.NETWORK_ERROR`).
+
+### Sentry (noise + recovery)
+
+- Init: `main.ts` — `beforeSend` drops chunk/module-import failures and status-0 HTTP noise
+  (`core/sentry/sentry-before-send.util.ts`).
+- ErrorHandler: `createAppSentryErrorHandler()` — one-time `location.reload()` on lazy chunk /
+  module-import failure (`sessionStorage` flag), then delegates to Sentry.
+- Successful bootstrap clears the chunk-recovery flag so a later deploy mismatch can recover once.
 
 ### Auth Architecture (django-allauth headless SPA)
 
@@ -400,7 +412,10 @@ success.
 - **Languages:** English (`en`), Arabic (`ar`)
 - **Default:** Arabic (`ar`) — set in both `index.html` and `app.config.ts`
 - **Persistence:** `localStorage.getItem('lang')`
-- **Switch:** Full page reload on language toggle (`LangSwitchComponent`)
+- **Bootstrap:** `initializeAppTranslations()` retries once; on final failure boots anyway (no
+  unhandled ErrorHandler) so flaky mobile loads of `/i18n/*.json` do not crash the app
+- **Switch:** Full page reload on language toggle (`LangSwitchComponent`); `App.switchLang` catches
+  failed `translate.use`
 - **RTL:** `<html dir="rtl">` with logical CSS properties (`margin-inline`, `padding-inline`)
 - **Keys:** 1483 per language (parity verified); domains include auth, navigation, gallery, admin,
   content standards, licenses, errors, forms, access-request license terms

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -28,6 +28,7 @@ import { appSessionTokenInterceptor } from './core/interceptors/app-session-toke
 import { tenantHeaderInterceptor } from './core/interceptors/tenant-header.interceptor';
 import { AuthService } from './core/auth/services/auth.service';
 import { initializeAppTranslations } from './core/i18n/translate-app.initializer';
+import { createAppSentryErrorHandler } from './core/sentry/sentry-error-handler';
 registerLocaleData(ar);
 
 export const appConfig: ApplicationConfig = {
@@ -39,7 +40,7 @@ export const appConfig: ApplicationConfig = {
       ? [
           {
             provide: ErrorHandler,
-            useValue: Sentry.createErrorHandler(),
+            useFactory: createAppSentryErrorHandler,
           },
           {
             provide: Sentry.TraceService,

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -78,11 +78,15 @@ export class App {
     const currentLang = localStorage.getItem('lang') || 'ar';
     const newLang = currentLang === 'ar' ? 'en' : 'ar';
     localStorage.setItem('lang', newLang);
-    void firstValueFrom(this.translate.use(newLang)).then(() => {
-      document.documentElement.setAttribute('lang', newLang);
-      document.documentElement.setAttribute('dir', newLang === 'ar' ? 'rtl' : 'ltr');
-      this.setAppTitle();
-    });
+    void firstValueFrom(this.translate.use(newLang))
+      .then(() => {
+        document.documentElement.setAttribute('lang', newLang);
+        document.documentElement.setAttribute('dir', newLang === 'ar' ? 'rtl' : 'ltr');
+        this.setAppTitle();
+      })
+      .catch((err: unknown) => {
+        console.error('Failed to switch UI language', err);
+      });
   }
 
   private setAppTitle(): void {

--- a/src/app/core/i18n/translate-app.initializer.spec.ts
+++ b/src/app/core/i18n/translate-app.initializer.spec.ts
@@ -1,33 +1,54 @@
 import { TestBed } from '@angular/core/testing';
-import { provideTranslateService, TranslateService } from '@ngx-translate/core';
-import { of } from 'rxjs';
-import { DEFAULT_UI_LANGUAGE, initializeAppTranslations } from './translate-app.initializer';
+import { TranslateService } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+import { initializeAppTranslations } from './translate-app.initializer';
 
 describe('initializeAppTranslations', () => {
-  it('loads the stored language before bootstrap continues', async () => {
-    localStorage.setItem('lang', 'en');
-    const useSpy = jasmine.createSpy('use').and.returnValue(of({}));
-    const setFallbackSpy = jasmine.createSpy('setFallbackLang');
-    const addLangsSpy = jasmine.createSpy('addLangs');
+  let translate: jasmine.SpyObj<TranslateService>;
 
+  beforeEach(() => {
+    translate = jasmine.createSpyObj<TranslateService>('TranslateService', [
+      'addLangs',
+      'setFallbackLang',
+      'use',
+    ]);
+    localStorage.removeItem('lang');
     TestBed.configureTestingModule({
-      providers: [
-        provideTranslateService(),
-        {
-          provide: TranslateService,
-          useValue: {
-            addLangs: addLangsSpy,
-            setFallbackLang: setFallbackSpy,
-            use: useSpy,
-          },
-        },
-      ],
+      providers: [{ provide: TranslateService, useValue: translate }],
     });
+  });
 
+  it('loads the default language on success', async () => {
+    translate.use.and.returnValue(of({}));
     await TestBed.runInInjectionContext(() => initializeAppTranslations());
+    expect(translate.addLangs).toHaveBeenCalledWith(['ar', 'en']);
+    expect(translate.setFallbackLang).toHaveBeenCalledWith('ar');
+    expect(translate.use).toHaveBeenCalledOnceWith('ar');
+  });
 
-    expect(addLangsSpy).toHaveBeenCalledWith(['ar', 'en']);
-    expect(setFallbackSpy).toHaveBeenCalledWith(DEFAULT_UI_LANGUAGE);
-    expect(useSpy).toHaveBeenCalledWith('en');
+  it('retries once after a failed load then succeeds', async () => {
+    translate.use.and.returnValues(
+      throwError(() => new Error('network')),
+      of({})
+    );
+    await TestBed.runInInjectionContext(() => initializeAppTranslations());
+    expect(translate.use).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves without throwing when both attempts fail', async () => {
+    translate.use.and.returnValue(throwError(() => new Error('network')));
+    const spy = spyOn(console, 'error');
+    await expectAsync(
+      TestBed.runInInjectionContext(() => initializeAppTranslations())
+    ).toBeResolved();
+    expect(translate.use).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('uses localStorage lang when set', async () => {
+    localStorage.setItem('lang', 'en');
+    translate.use.and.returnValue(of({}));
+    await TestBed.runInInjectionContext(() => initializeAppTranslations());
+    expect(translate.use).toHaveBeenCalledOnceWith('en');
   });
 });

--- a/src/app/core/i18n/translate-app.initializer.ts
+++ b/src/app/core/i18n/translate-app.initializer.ts
@@ -4,11 +4,28 @@ import { firstValueFrom } from 'rxjs';
 
 export const DEFAULT_UI_LANGUAGE = 'ar';
 
-/** Load UI translations before bootstrap so Arabic (default) does not flash raw i18n keys. */
-export function initializeAppTranslations(): Promise<unknown> {
+async function loadLanguage(translate: TranslateService, lang: string): Promise<unknown> {
+  return firstValueFrom(translate.use(lang));
+}
+
+/**
+ * Load UI translations before bootstrap so Arabic (default) does not flash raw i18n keys.
+ * Retries once on failure; on final failure boots anyway (avoids unhandled ErrorHandler noise).
+ */
+export async function initializeAppTranslations(): Promise<unknown> {
   const translate = inject(TranslateService);
   const lang = localStorage.getItem('lang') || DEFAULT_UI_LANGUAGE;
   translate.addLangs(['ar', 'en']);
   translate.setFallbackLang(DEFAULT_UI_LANGUAGE);
-  return firstValueFrom(translate.use(lang));
+
+  try {
+    return await loadLanguage(translate, lang);
+  } catch {
+    try {
+      return await loadLanguage(translate, lang);
+    } catch (err) {
+      console.error('Failed to load UI translations after retry', err);
+      return undefined;
+    }
+  }
 }

--- a/src/app/core/interceptors/auth-error-sentry-suppress.util.spec.ts
+++ b/src/app/core/interceptors/auth-error-sentry-suppress.util.spec.ts
@@ -1,9 +1,22 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
-import { shouldSuppressSentryForHeadlessHttpError } from './auth-error-sentry-suppress.util';
+import {
+  isNetworkAbortHttpError,
+  shouldSuppressSentryForHeadlessHttpError,
+} from './auth-error-sentry-suppress.util';
 
 describe('shouldSuppressSentryForHeadlessHttpError', () => {
   const api = environment.API_BASE_URL;
+
+  it('is true for status 0 network abort on any URL', () => {
+    const err = new HttpErrorResponse({
+      status: 0,
+      statusText: 'Unknown Error',
+      url: '/i18n/ar.json',
+    });
+    expect(isNetworkAbortHttpError(err)).toBe(true);
+    expect(shouldSuppressSentryForHeadlessHttpError('/i18n/ar.json', 'GET', err)).toBe(true);
+  });
 
   it('is true for 409 unverified_email on headless app URL', () => {
     if (!api) {

--- a/src/app/core/interceptors/auth-error-sentry-suppress.util.ts
+++ b/src/app/core/interceptors/auth-error-sentry-suppress.util.ts
@@ -24,6 +24,11 @@ export function isExpectedTotpAuthenticatorStatusProbe404(
   );
 }
 
+/** Aborted / offline / unreachable XHR (Angular status 0) — not an application bug. */
+export function isNetworkAbortHttpError(error: HttpErrorResponse): boolean {
+  return error.status === 0;
+}
+
 /** Expected business responses that should not be reported as unexpected errors. */
 export function shouldSuppressSentryForHeadlessHttpError(
   reqUrl: string,
@@ -31,6 +36,7 @@ export function shouldSuppressSentryForHeadlessHttpError(
   error: HttpErrorResponse
 ): boolean {
   return (
+    isNetworkAbortHttpError(error) ||
     (isHeadlessAppAuthUrl(reqUrl) && isUnverifiedEmailError(error)) ||
     (isHeadlessAppAuthUrl(reqUrl) && isWebAuthnIncorrectCodeError(error)) ||
     isExpectedTotpAuthenticatorStatusProbe404(reqUrl, reqMethod, error)

--- a/src/app/core/sentry/chunk-load-error.util.spec.ts
+++ b/src/app/core/sentry/chunk-load-error.util.spec.ts
@@ -1,0 +1,78 @@
+import {
+  CHUNK_LOAD_RECOVERY_FLAG,
+  isChunkLoadError,
+  tryRecoverFromChunkLoadError,
+} from './chunk-load-error.util';
+
+describe('chunk-load-error.util', () => {
+  describe('isChunkLoadError', () => {
+    it('matches WebKit module script failure', () => {
+      expect(isChunkLoadError(new TypeError('Importing a module script failed.'))).toBe(true);
+    });
+
+    it('matches webpack ChunkLoadError', () => {
+      const err = new Error(
+        'Loading chunk 22S5FMW7 failed.\n(error: https://cms.itqan.dev/chunk-22S5FMW7.js)'
+      );
+      err.name = 'ChunkLoadError';
+      expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('matches failed dynamic import message', () => {
+      expect(
+        isChunkLoadError(
+          new TypeError('Failed to fetch dynamically imported module: https://x/a.js')
+        )
+      ).toBe(true);
+    });
+
+    it('rejects unrelated errors', () => {
+      expect(isChunkLoadError(new Error('NullInjectorError'))).toBe(false);
+      expect(isChunkLoadError(null)).toBe(false);
+    });
+  });
+
+  describe('tryRecoverFromChunkLoadError', () => {
+    let storage: Storage;
+    let store: Record<string, string>;
+    let reload: jasmine.Spy;
+
+    beforeEach(() => {
+      store = {};
+      storage = {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = String(v);
+        },
+        removeItem: (k: string) => {
+          delete store[k];
+        },
+        clear: () => {
+          store = {};
+        },
+        key: () => null,
+        length: 0,
+      };
+      reload = jasmine.createSpy('reload');
+    });
+
+    it('reloads once and sets the recovery flag', () => {
+      const err = new TypeError('Importing a module script failed.');
+      expect(tryRecoverFromChunkLoadError(err, storage, reload)).toBe(true);
+      expect(reload).toHaveBeenCalledTimes(1);
+      expect(storage.getItem(CHUNK_LOAD_RECOVERY_FLAG)).toBe('1');
+    });
+
+    it('does not reload when the flag is already set', () => {
+      storage.setItem(CHUNK_LOAD_RECOVERY_FLAG, '1');
+      const err = new TypeError('Importing a module script failed.');
+      expect(tryRecoverFromChunkLoadError(err, storage, reload)).toBe(false);
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('returns false for non-chunk errors', () => {
+      expect(tryRecoverFromChunkLoadError(new Error('boom'), storage, reload)).toBe(false);
+      expect(reload).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/core/sentry/chunk-load-error.util.ts
+++ b/src/app/core/sentry/chunk-load-error.util.ts
@@ -1,0 +1,64 @@
+/** sessionStorage key: one automatic reload after a chunk/module-import failure. */
+export const CHUNK_LOAD_RECOVERY_FLAG = 'cms.chunkLoadRecoveryAttempted';
+
+const CHUNK_LOAD_MESSAGE_PATTERNS: RegExp[] = [
+  /Importing a module script failed/i,
+  /Loading chunk [\w-]+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /ChunkLoadError/i,
+];
+
+function errorMessage(error: unknown): string {
+  if (error == null) {
+    return '';
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message || error.name || '';
+  }
+  if (typeof error === 'object' && 'message' in error) {
+    const msg = (error as { message?: unknown }).message;
+    if (typeof msg === 'string') {
+      return msg;
+    }
+  }
+  return String(error);
+}
+
+/** True when the error is a failed lazy chunk / dynamic module import. */
+export function isChunkLoadError(error: unknown): boolean {
+  const message = errorMessage(error);
+  if (CHUNK_LOAD_MESSAGE_PATTERNS.some((re) => re.test(message))) {
+    return true;
+  }
+  if (error instanceof Error && error.name === 'ChunkLoadError') {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * On first chunk/module-import failure in this tab, hard-reload once.
+ * Returns true when recovery was triggered (caller should not rethrow/report).
+ */
+export function tryRecoverFromChunkLoadError(
+  error: unknown,
+  storage: Storage = sessionStorage,
+  reload: () => void = () => location.reload()
+): boolean {
+  if (!isChunkLoadError(error)) {
+    return false;
+  }
+  try {
+    if (storage.getItem(CHUNK_LOAD_RECOVERY_FLAG) === '1') {
+      return false;
+    }
+    storage.setItem(CHUNK_LOAD_RECOVERY_FLAG, '1');
+  } catch {
+    // Private mode / blocked storage: still attempt a single reload path via flag miss.
+  }
+  reload();
+  return true;
+}

--- a/src/app/core/sentry/sentry-before-send.util.spec.ts
+++ b/src/app/core/sentry/sentry-before-send.util.spec.ts
@@ -1,0 +1,61 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import type { ErrorEvent, EventHint } from '@sentry/angular';
+import { filterBenignNetworkSentryEvent } from './sentry-before-send.util';
+
+function eventWithMessage(message: string, type = 'Error'): ErrorEvent {
+  return {
+    type: undefined,
+    exception: {
+      values: [{ type, value: message }],
+    },
+  } as ErrorEvent;
+}
+
+describe('filterBenignNetworkSentryEvent', () => {
+  it('drops Importing a module script failed', () => {
+    const event = eventWithMessage('Importing a module script failed.', 'TypeError');
+    expect(filterBenignNetworkSentryEvent(event)).toBeNull();
+  });
+
+  it('drops Http failure response status 0 message', () => {
+    const event = eventWithMessage('Http failure response for /i18n/ar.json: 0 Unknown Error');
+    expect(filterBenignNetworkSentryEvent(event)).toBeNull();
+  });
+
+  it('drops originalException HttpErrorResponse with status 0', () => {
+    const event = eventWithMessage('something else');
+    const hint: EventHint = {
+      originalException: new HttpErrorResponse({
+        status: 0,
+        statusText: 'Unknown Error',
+        url: '/i18n/ar.json',
+      }),
+    };
+    expect(filterBenignNetworkSentryEvent(event, hint)).toBeNull();
+  });
+
+  it('drops object-captured HTTP response shape noise', () => {
+    const event = eventWithMessage(
+      'Object captured as exception with keys: error, headers, message, name, ok, redirected, status, statusText, type, url'
+    );
+    expect(filterBenignNetworkSentryEvent(event)).toBeNull();
+  });
+
+  it('keeps unrelated application errors', () => {
+    const event = eventWithMessage('NullInjectorError: No provider for Foo');
+    expect(filterBenignNetworkSentryEvent(event)).toBe(event);
+  });
+
+  it('keeps non-zero HTTP failures', () => {
+    const event = eventWithMessage(
+      'Http failure response for /cms-api/assets/: 500 Internal Server Error'
+    );
+    const hint: EventHint = {
+      originalException: new HttpErrorResponse({
+        status: 500,
+        statusText: 'Internal Server Error',
+      }),
+    };
+    expect(filterBenignNetworkSentryEvent(event, hint)).toBe(event);
+  });
+});

--- a/src/app/core/sentry/sentry-before-send.util.ts
+++ b/src/app/core/sentry/sentry-before-send.util.ts
@@ -1,0 +1,66 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import type { ErrorEvent, EventHint } from '@sentry/angular';
+import { isChunkLoadError } from './chunk-load-error.util';
+
+const STATUS_ZERO_HTTP_MESSAGE = /Http failure response for [^:]+: 0(?:\s+Unknown Error)?/i;
+
+const OBJECT_CAPTURED_STATUS_KEYS = /Object captured as exception with keys:.*\bstatus\b/i;
+
+function eventExceptionMessages(event: ErrorEvent): string[] {
+  const values = event.exception?.values ?? [];
+  const fromException = values
+    .map((v) => [v.value, v.type].filter(Boolean).join(' '))
+    .filter((s): s is string => !!s);
+  if (typeof event.message === 'string' && event.message) {
+    return [...fromException, event.message];
+  }
+  return fromException;
+}
+
+function isStatusZeroNetworkFailure(error: unknown): boolean {
+  if (error instanceof HttpErrorResponse) {
+    return error.status === 0;
+  }
+  if (error && typeof error === 'object' && 'status' in error) {
+    return (error as { status?: unknown }).status === 0;
+  }
+  return false;
+}
+
+function isBenignNetworkNoiseMessage(message: string): boolean {
+  if (STATUS_ZERO_HTTP_MESSAGE.test(message)) {
+    return true;
+  }
+  if (OBJECT_CAPTURED_STATUS_KEYS.test(message) && /\bstatus\b/i.test(message)) {
+    // Plain-object capture of aborted XHR/fetch shapes (status 0 / network abort).
+    // Only drop when the captured-keys list looks like an HTTP response object.
+    return /\bok\b/i.test(message) && (/\burl\b/i.test(message) || /\bstatusText\b/i.test(message));
+  }
+  return false;
+}
+
+/**
+ * Drop benign mobile/WebKit network abort and chunk-import failures from Sentry.
+ * Returns null to discard; otherwise returns the event unchanged.
+ */
+export function filterBenignNetworkSentryEvent(
+  event: ErrorEvent,
+  hint?: EventHint
+): ErrorEvent | null {
+  const original = hint?.originalException;
+
+  if (isChunkLoadError(original)) {
+    return null;
+  }
+  if (isStatusZeroNetworkFailure(original)) {
+    return null;
+  }
+
+  for (const msg of eventExceptionMessages(event)) {
+    if (isChunkLoadError(msg) || isBenignNetworkNoiseMessage(msg)) {
+      return null;
+    }
+  }
+
+  return event;
+}

--- a/src/app/core/sentry/sentry-error-handler.ts
+++ b/src/app/core/sentry/sentry-error-handler.ts
@@ -1,0 +1,20 @@
+import { ErrorHandler } from '@angular/core';
+import * as Sentry from '@sentry/angular';
+import { tryRecoverFromChunkLoadError } from './chunk-load-error.util';
+
+/**
+ * Recovers from lazy-chunk / module-import failures with a one-time reload,
+ * then delegates remaining errors to Sentry's Angular ErrorHandler.
+ */
+export function createAppSentryErrorHandler(): ErrorHandler {
+  const sentryHandler = Sentry.createErrorHandler();
+
+  return {
+    handleError(error: unknown): void {
+      if (tryRecoverFromChunkLoadError(error)) {
+        return;
+      }
+      sentryHandler.handleError(error);
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { appConfig } from './app/app.config';
 import { App } from './app/app';
 import * as Sentry from '@sentry/angular';
 import { environment } from './environments/environment';
+import { CHUNK_LOAD_RECOVERY_FLAG } from './app/core/sentry/chunk-load-error.util';
+import { filterBenignNetworkSentryEvent } from './app/core/sentry/sentry-before-send.util';
 
 if (environment.sentryDsn) {
   Sentry.init({
@@ -15,7 +17,19 @@ if (environment.sentryDsn) {
       /^https:\/\/.*\.api\.cms\.itqan\.dev/,
       /^https:\/\/api\.cms\.itqan\.dev/,
     ],
+    beforeSend(event, hint) {
+      return filterBenignNetworkSentryEvent(event, hint);
+    },
   });
 }
 
-bootstrapApplication(App, appConfig).catch((err) => console.error(err));
+bootstrapApplication(App, appConfig)
+  .then(() => {
+    // Successful boot: allow a future chunk-load failure in this tab to recover once.
+    try {
+      sessionStorage.removeItem(CHUNK_LOAD_RECOVERY_FLAG);
+    } catch {
+      /* ignore */
+    }
+  })
+  .catch((err) => console.error(err));


### PR DESCRIPTION
- Auto-reload once when a chunk fails to load (standard SPA recovery).
- Retry translation load, and don’t crash the app if it still fails.
- Stop sending these benign network/abort errors to Sentry so they don’t create false high-priority alerts.