### PR TITLE
fix(ci): release job push blocked by master branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,11 @@ jobs:
       - name: Run semantic-release
         run: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # master requires 1 PR approval; the default GITHUB_TOKEN authenticates
+          # as github-actions[bot], which isn't exempted by that rule (only real
+          # admin users are). Use an admin-owned PAT so the release commit/tag push
+          # can go through directly, matching how admins already merge PRs here.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Record post-release version


### PR DESCRIPTION
## Problem
The \`release\` job's semantic-release push (\`@semantic-release/git\`, pushing a \`chore(release): X.Y.Z [skip ci]\` commit + tags to \`master\`) has been failing on every merge to master with:
\`\`\`
remote: error: GH006: Protected branch update failed for refs/heads/master.
\`\`\`

Root cause: \`master\`'s branch protection requires 1 PR approval. \`enforce_admins\` is off, which exempts real admin *users* from that requirement, but the default \`secrets.GITHUB_TOKEN\` authenticates as the \`github-actions[bot]\` identity, which isn't a "real admin user" and gets blocked like anyone else.

I also tried migrating master's classic protection to a ruleset with a bypass actor for the GitHub Actions app (mirroring staging's existing ruleset bypass) — GitHub rejects this, since the built-in Actions runner isn't a registered org-installed Integration eligible for ruleset bypass.

## Fix
Added \`RELEASE_ADMIN_TOKEN\` repo secret (an admin-owned PAT) and use it instead of \`secrets.GITHUB_TOKEN\` for just the \`Run semantic-release\` step, so the push authenticates as a real admin user and bypasses the rule the same way manual PR merges already do.

## Verification
This will only be provable by watching the next push-to-master CI run succeed on the \`release\` job (all other jobs — lint-and-test, type-check, build-check — were never affected, only \`release\`).