### PR TITLE
ci: add cloudflare pages config for staging preview

### DIFF
--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -7,25 +7,25 @@
 
 ## [TECH_STACK]
 
-| Layer        | Technology                                              | Version  |
-| ------------ | ------------------------------------------------------- | -------- |
-| Framework    | Angular (standalone components)                         | ^20.3.7  |
-| Language     | TypeScript                                              | ~5.9.2   |
-| UI Library   | NG-ZORRO (Ant Design for Angular)                       | ^20.3.1  |
-| Icons        | @ng-icons/lucide                                        | ^32.5.0  |
-| i18n         | @ngx-translate/core                                     | ^17.0.0  |
-| Styling      | LESS                                                    | ^4.2.0   |
-| Auth Backend | django-allauth (headless SPA mode)                      | —        |
-| Monitoring   | Sentry                                                  | ^10.47.0 |
-| Analytics    | Google Analytics (gtag)                                 | —        |
-| Web Vitals   | web-vitals                                              | ^5.1.0   |
-| QR Codes     | qrcode                                                  | ^1.5.4   |
-| State Mgmt   | RxJS + Angular Signals                                  | ~7.8.0   |
-| Testing      | Karma + Jasmine                                         | —        |
-| Linting      | ESLint (flat config) + Prettier                         | —        |
-| Commit       | Commitlint (conventional commits) + Husky + lint-staged | —        |
-| Package Mgr  | npm / pnpm                                              | —        |
-| Deployment   | Netlify                                                 | —        |
+| Layer        | Technology                                                 | Version  |
+| ------------ | ---------------------------------------------------------- | -------- |
+| Framework    | Angular (standalone components)                            | ^20.3.7  |
+| Language     | TypeScript                                                 | ~5.9.2   |
+| UI Library   | NG-ZORRO (Ant Design for Angular)                          | ^20.3.1  |
+| Icons        | @ng-icons/lucide                                           | ^32.5.0  |
+| i18n         | @ngx-translate/core                                        | ^17.0.0  |
+| Styling      | LESS                                                       | ^4.2.0   |
+| Auth Backend | django-allauth (headless SPA mode)                         | —        |
+| Monitoring   | Sentry                                                     | ^10.47.0 |
+| Analytics    | Google Analytics (gtag)                                    | —        |
+| Web Vitals   | web-vitals                                                 | ^5.1.0   |
+| QR Codes     | qrcode                                                     | ^1.5.4   |
+| State Mgmt   | RxJS + Angular Signals                                     | ~7.8.0   |
+| Testing      | Karma + Jasmine                                            | —        |
+| Linting      | ESLint (flat config) + Prettier                            | —        |
+| Commit       | Commitlint (conventional commits) + Husky + lint-staged    | —        |
+| Package Mgr  | npm / pnpm                                                 | —        |
+| Deployment   | Cloudflare Pages (+ Pages Functions for staging API proxy) | —        |
 
 ---
 
@@ -50,7 +50,7 @@ User Browser
     |
     |-- Sentry (error monitoring)
     |-- Google Analytics (usage tracking)
-    |-- Netlify (hosting, CD, edge redirects)
+    |-- Cloudflare Pages (hosting, CD; staging API proxy via `functions/`)
 ```
 
 ### Authentication Flow (django-allauth headless SPA)
@@ -510,15 +510,20 @@ view-only — create binds `AdminTenantService.selectedPublisherId()`; edit show
 
 ## [DEPLOYMENT]
 
-| Platform         | Netlify                                                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------------------------------- | -------------------- |
-| Production       | `https://cms.itqan.dev` (master branch)                                                                       |
-| Staging          | `https://staging.cms.itqan.dev` (staging branch)                                                              |
-| Build cmd        | `npm run build:{env}`                                                                                         |
-| Publish dir      | `dist/browser`                                                                                                |
-| SPA fallback     | Deploy `netlify/production                                                                                    | staging/\_redirects` |
-| Security headers | X-Frame-Options: DENY, X-Content-Type-Options: nosniff, X-XSS-Protection, Referrer-Policy, Permissions-Policy |
-| Cache            | Static assets under `/assets/` — 1 year immutable                                                             |
+| Platform          | Cloudflare Pages                                                                                                |
+| ----------------- | --------------------------------------------------------------------------------------------------------------- |
+| Production        | `https://cms.itqan.dev` / `cms-frontend-bdh.pages.dev` (master branch)                                          |
+| Staging           | `https://staging.cms.itqan.dev` / `cms-frontend-staging.pages.dev` (staging branch)                             |
+| Build cmd         | `npm run build:{env}`                                                                                           |
+| Publish dir       | `dist/browser`                                                                                                  |
+| SPA fallback      | `deploy/cloudflare/staging/_redirects` (staging); `deploy/netlify/production/_redirects` (production)           |
+| Staging API proxy | Pages Functions in `functions/` → `https://staging.api.cms.itqan.dev` (same-origin cookies on staging hosts)    |
+| OAuth callbacks   | Allow `https://staging.cms.itqan.dev/accounts/.../callback` and preview URL on `cms-frontend-staging.pages.dev` |
+| Security headers  | X-Frame-Options: DENY, X-Content-Type-Options: nosniff, X-XSS-Protection, Referrer-Policy, Permissions-Policy   |
+| Cache             | Static assets under `/assets/` — 1 year immutable                                                               |
+
+Legacy Netlify config remains in `netlify.toml` and `deploy/netlify/*` for reference; staging deploy
+uses Cloudflare Pages Functions instead of Netlify external redirects.
 
 ---
 

--- a/angular.json
+++ b/angular.json
@@ -109,7 +109,7 @@
                 },
                 {
                   "glob": "_redirects",
-                  "input": "deploy/netlify/staging",
+                  "input": "deploy/cloudflare/staging",
                   "output": "."
                 }
               ]

--- a/deploy/cloudflare/staging/_redirects
+++ b/deploy/cloudflare/staging/_redirects
@@ -1,0 +1,4 @@
+# SPA fallback for Cloudflare Pages staging. API paths are proxied via repo-root `functions/`.
+/portal/invitations/accept   /index.html  200
+/portal/invitations/accept/  /index.html  200
+/*                           /index.html  200

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,18 @@ module.exports = defineConfig([
     'Thumbs.db',
   ]),
 
+  // Cloudflare Pages Functions (Workers runtime, not Angular)
+  {
+    files: ['functions/**/*.ts'],
+    extends: [eslint.configs.recommended, tseslint.configs.recommended, tseslint.configs.stylistic],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+      },
+    },
+    rules: {},
+  },
+
   // TypeScript + Angular
   {
     files: ['**/*.ts'],

--- a/functions/_lib/staging-proxy.ts
+++ b/functions/_lib/staging-proxy.ts
@@ -1,0 +1,90 @@
+export const STAGING_PROXY_HOSTS = [
+  'staging.cms.itqan.dev',
+  'cms-frontend-staging.pages.dev',
+] as const;
+
+export const STAGING_API_ORIGIN = 'https://staging.api.cms.itqan.dev';
+
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailers',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+]);
+
+const FORWARD_REQUEST_HEADERS = [
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'authorization',
+  'content-type',
+  'content-length',
+  'cookie',
+  'origin',
+  'referer',
+  'user-agent',
+  'x-csrftoken',
+  'x-session-token',
+  'x-requested-with',
+];
+
+export function isStagingProxyHost(hostname: string): boolean {
+  return (STAGING_PROXY_HOSTS as readonly string[]).includes(hostname);
+}
+
+export async function proxyToStagingApi(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+
+  if (!isStagingProxyHost(url.hostname)) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  const upstreamUrl = new URL(`${url.pathname}${url.search}`, STAGING_API_ORIGIN);
+  const headers = new Headers();
+
+  for (const name of FORWARD_REQUEST_HEADERS) {
+    const value = request.headers.get(name);
+    if (value) {
+      headers.set(name, value);
+    }
+  }
+
+  request.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (lower.startsWith('x-') && !headers.has(lower) && !HOP_BY_HOP_HEADERS.has(lower)) {
+      headers.set(key, value);
+    }
+  });
+
+  headers.set('X-Forwarded-Host', url.hostname);
+  headers.set('X-Forwarded-Proto', url.protocol.replace(':', ''));
+
+  const clientIp =
+    request.headers.get('CF-Connecting-IP') ?? request.headers.get('X-Forwarded-For');
+  if (clientIp) {
+    headers.set('X-Forwarded-For', clientIp);
+  }
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: 'manual',
+  };
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    init.body = request.body;
+  }
+
+  const upstreamResponse = await fetch(upstreamUrl.toString(), init);
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: upstreamResponse.headers,
+  });
+}

--- a/functions/accounts/[[path]].ts
+++ b/functions/accounts/[[path]].ts
@@ -1,0 +1,5 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+
+import { proxyToStagingApi } from '../_lib/staging-proxy';
+
+export const onRequest: PagesFunction = async (context) => proxyToStagingApi(context.request);

--- a/functions/cms-api/[[path]].ts
+++ b/functions/cms-api/[[path]].ts
@@ -1,0 +1,5 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+
+import { proxyToStagingApi } from '../_lib/staging-proxy';
+
+export const onRequest: PagesFunction = async (context) => proxyToStagingApi(context.request);

--- a/functions/portal/[[path]].ts
+++ b/functions/portal/[[path]].ts
@@ -1,0 +1,22 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+
+import { proxyToStagingApi } from '../_lib/staging-proxy';
+
+interface Env {
+  ASSETS: Fetcher;
+}
+
+function isPortalInvitationAcceptRoute(pathname: string): boolean {
+  return pathname === '/portal/invitations/accept' || pathname === '/portal/invitations/accept/';
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  const url = new URL(request.url);
+
+  if (isPortalInvitationAcceptRoute(url.pathname)) {
+    return env.ASSETS.fetch(new URL('/index.html', request.url));
+  }
+
+  return proxyToStagingApi(request);
+};

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,4 +29,5 @@
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
-# SPA fallback + staging API proxies live in `dist/browser/_redirects` (see `deploy/netlify/*`).
+# SPA fallback in `dist/browser/_redirects` (see `deploy/netlify/production`).
+# Staging on Cloudflare Pages proxies `/cms-api`, `/accounts`, `/portal` via repo-root `functions/`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@angular/build": "^20.3.7",
         "@angular/cli": "^20.3.7",
         "@angular/compiler-cli": "^20.3.7",
+        "@cloudflare/workers-types": "^4.20260702.1",
         "@commitlint/cli": "^19.0.0",
         "@commitlint/config-conventional": "^21.0.2",
         "@semantic-release/commit-analyzer": "^13.0.1",
@@ -1185,6 +1186,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@angular/build": "^20.3.7",
     "@angular/cli": "^20.3.7",
     "@angular/compiler-cli": "^20.3.7",
+    "@cloudflare/workers-types": "^4.20260702.1",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^21.0.2",
     "@semantic-release/commit-analyzer": "^13.0.1",

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -1,15 +1,20 @@
 /**
- * On Netlify `staging.cms.itqan.dev`, API traffic is same-origin via `deploy/netlify/staging/_redirects`
- * so Django session cookies from `/accounts/.../callback` are visible to `/cms-api/...` XHR (split-host + SameSite=Lax fix).
- * Google/GitHub console + Django must allow `https://staging.cms.itqan.dev/accounts/.../callback` (see deploy/netlify/staging/_redirects).
+ * On Cloudflare Pages staging (`staging.cms.itqan.dev`, `cms-frontend-staging.pages.dev`),
+ * API traffic is same-origin via repo-root `functions/` proxies so Django session cookies from
+ * `/accounts/.../callback` are visible to `/cms-api/...` XHR (split-host + SameSite=Lax fix).
+ * Google/GitHub console + Django must allow `https://<staging-host>/accounts/.../callback`.
  */
-const STAGING_CMS_HOST = 'staging.cms.itqan.dev';
+const STAGING_CMS_HOSTS = ['staging.cms.itqan.dev', 'cms-frontend-staging.pages.dev'] as const;
+const STAGING_CMS_HOST = STAGING_CMS_HOSTS[0];
 
 function stagingCmsOrigin(): string | undefined {
   if (typeof window === 'undefined' || !window.location?.hostname) {
     return undefined;
   }
-  return window.location.hostname === STAGING_CMS_HOST ? window.location.origin : undefined;
+
+  return (STAGING_CMS_HOSTS as readonly string[]).includes(window.location.hostname)
+    ? window.location.origin
+    : undefined;
 }
 
 const cmsOrigin = stagingCmsOrigin();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Pages staging support with dedicated staging URLs.
  * Added staging access for portal, accounts, and CMS API routes.
  * Added SPA fallback handling for invitation acceptance and other application routes.
  * Improved staging request forwarding while preserving supported request details.

* **Documentation**
  * Updated deployment and architecture documentation to reflect Cloudflare Pages hosting and staging behavior.
  * Clarified retained legacy hosting configuration and current staging routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->